### PR TITLE
feat(sync): Refine Master Product Sync and UI Labels

### DIFF
--- a/apps/api/drizzle/0009_even_joseph.sql
+++ b/apps/api/drizzle/0009_even_joseph.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `master_product_variants` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`master_product_id` int NOT NULL,
+	`sku` varchar(100) NOT NULL,
+	`name` varchar(255) NOT NULL,
+	`stock` int NOT NULL DEFAULT 0,
+	CONSTRAINT `master_product_variants_id` PRIMARY KEY(`id`),
+	CONSTRAINT `master_product_variants_sku_unique` UNIQUE(`sku`)
+);
+--> statement-breakpoint
+ALTER TABLE `master_product_variants` ADD CONSTRAINT `master_product_variants_master_product_id_master_products_id_fk` FOREIGN KEY (`master_product_id`) REFERENCES `master_products`(`id`) ON DELETE cascade ON UPDATE no action;

--- a/apps/api/drizzle/meta/0009_snapshot.json
+++ b/apps/api/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,684 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "1a2b812e-4efe-4140-bc15-b03ca90a24fd",
+  "prevId": "157116ad-0356-45be-87f3-a014dfd6b1fd",
+  "tables": {
+    "master_product_variants": {
+      "name": "master_product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "master_product_id": {
+          "name": "master_product_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "master_product_variants_master_product_id_master_products_id_fk": {
+          "name": "master_product_variants_master_product_id_master_products_id_fk",
+          "tableFrom": "master_product_variants",
+          "tableTo": "master_products",
+          "columnsFrom": [
+            "master_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "master_product_variants_id": {
+          "name": "master_product_variants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "master_product_variants_sku_unique": {
+          "name": "master_product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "master_products": {
+      "name": "master_products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "master_products_id": {
+          "name": "master_products_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "master_products_sku_unique": {
+          "name": "master_products_sku_unique",
+          "columns": [
+            "sku"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "product_groups": {
+      "name": "product_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shopee_item_id": {
+          "name": "shopee_item_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_sku": {
+          "name": "item_sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_status": {
+          "name": "item_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'NORMAL'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uniq_shopee_item_id": {
+          "name": "uniq_shopee_item_id",
+          "columns": [
+            "shop_id",
+            "shopee_item_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "product_groups_id": {
+          "name": "product_groups_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "master_product_id": {
+          "name": "master_product_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shopee_item_id": {
+          "name": "shopee_item_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shopee_model_id": {
+          "name": "shopee_model_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_sku": {
+          "name": "model_sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shopee_stock": {
+          "name": "shopee_stock",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock": {
+          "name": "stock",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uniq_shopee_model_id": {
+          "name": "uniq_shopee_model_id",
+          "columns": [
+            "shop_id",
+            "shopee_model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "products_master_product_id_master_products_id_fk": {
+          "name": "products_master_product_id_master_products_id_fk",
+          "tableFrom": "products",
+          "tableTo": "master_products",
+          "columnsFrom": [
+            "master_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_group_id_product_groups_id_fk": {
+          "name": "products_group_id_product_groups_id_fk",
+          "tableFrom": "products",
+          "tableTo": "product_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "products_id": {
+          "name": "products_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "shopee_credentials": {
+      "name": "shopee_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "partner_key": {
+          "name": "partner_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shop_name": {
+          "name": "shop_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uniq_shop_id": {
+          "name": "uniq_shop_id",
+          "columns": [
+            "shop_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "shopee_credentials_id": {
+          "name": "shopee_credentials_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "shopee_order_items": {
+      "name": "shopee_order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "order_sn": {
+          "name": "order_sn",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qty": {
+          "name": "qty",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "item_price": {
+          "name": "item_price",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "shopee_order_items_id": {
+          "name": "shopee_order_items_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "shopee_orders": {
+      "name": "shopee_orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_sn": {
+          "name": "order_sn",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "buyer_username": {
+          "name": "buyer_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_carrier": {
+          "name": "shipping_carrier",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_time": {
+          "name": "pay_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "create_time": {
+          "name": "create_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uniq_order_sn": {
+          "name": "uniq_order_sn",
+          "columns": [
+            "order_sn"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "shopee_orders_id": {
+          "name": "shopee_orders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "shopee_orders_order_sn_unique": {
+          "name": "shopee_orders_order_sn_unique",
+          "columns": [
+            "order_sn"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776950402069,
       "tag": "0008_shocking_ozymandias",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1776989232616,
+      "tag": "0009_even_joseph",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -8,6 +8,14 @@ export const masterProducts = mysqlTable("master_products", {
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 
+export const masterProductVariants = mysqlTable("master_product_variants", {
+  id: int("id").primaryKey().autoincrement(),
+  masterProductId: int("master_product_id").notNull().references(() => masterProducts.id, { onDelete: "cascade" }),
+  sku: varchar("sku", { length: 100 }).notNull().unique(),
+  name: varchar("name", { length: 255 }).notNull(),
+  stock: int("stock").notNull().default(0),
+});
+
 export const productGroups = mysqlTable("product_groups", {
   id: int("id").primaryKey().autoincrement(),
   shopId: int("shop_id").notNull(),

--- a/apps/api/src/modules/master/master.route.ts
+++ b/apps/api/src/modules/master/master.route.ts
@@ -9,6 +9,7 @@ import {
   updateMasterProduct,
   deleteMasterProduct,
   unlinkProductGroup,
+  updateMasterVariants,
 } from "../../services/master.service";
 
 export const masterRoutes = new Elysia({ prefix: "/master" })
@@ -30,6 +31,31 @@ export const masterRoutes = new Elysia({ prefix: "/master" })
       body: t.Object({
         master_product_id: t.Number(),
         stock: t.Number(),
+      }),
+    }
+  )
+
+  // ─── Update Master Variants ──────────────────────────
+  .post(
+    "/update-variants",
+    async ({ body, set }) => {
+      try {
+        const result = await updateMasterVariants(body.master_product_id, body.variants);
+        return { success: true, data: result };
+      } catch (error: any) {
+        set.status = 500;
+        return { success: false, message: error.message };
+      }
+    },
+    {
+      body: t.Object({
+        master_product_id: t.Number(),
+        variants: t.Array(t.Object({
+          id: t.Optional(t.Number()),
+          sku: t.String(),
+          name: t.String(),
+          stock: t.Number(),
+        })),
       }),
     }
   )

--- a/apps/api/src/modules/order/order.route.ts
+++ b/apps/api/src/modules/order/order.route.ts
@@ -19,7 +19,7 @@ export const orderRoutes = new Elysia({ prefix: "/orders" })
 
   // Sync orders from Shopee (Last 15 days)
   .post("/sync", async ({ body }) => {
-    const { shop_id, days_back } = body as { shop_id?: number, days_back?: number };
+    const { shop_id, days_back, cursor, shop_index = 0 } = body as { shop_id?: number, days_back?: number, cursor?: string, shop_index?: number };
     
     let shopsToSync = [];
     if (shop_id) {
@@ -32,13 +32,35 @@ export const orderRoutes = new Elysia({ prefix: "/orders" })
       throw new Error("Tidak ada toko yang terhubung untuk menarik pesanan.");
     }
 
+    if (shop_index >= shopsToSync.length) {
+      return { success: true, data: { fetched: 0, has_more: false, next_cursor: "", shop_index: 0 } };
+    }
+
     try {
-      let totalSynced = 0;
-      for (const shop of shopsToSync) {
-         const result = await syncShopeeOrdersService(shop.shopId, days_back || 15);
-         totalSynced += result.syncedCount;
+      const currentShopId = shopsToSync[shop_index].shopId;
+      const result = await syncShopeeOrdersService(currentShopId, days_back || 15, cursor || "");
+      
+      let next_cursor = result.next_cursor;
+      let has_more = result.has_more;
+      let next_shop_index = shop_index;
+
+      // Jika satu toko sudah selesai, lanjut ke toko berikutnya jika ada
+      if (!has_more && shop_index + 1 < shopsToSync.length) {
+         has_more = true;
+         next_cursor = "";
+         next_shop_index = shop_index + 1;
       }
-      return { success: true, message: `Berhasil menarik ${totalSynced} pesanan.`, syncedCount: totalSynced };
+
+      return { 
+        success: true, 
+        message: `Berhasil menarik ${result.syncedCount} pesanan.`, 
+        data: { 
+          fetched: result.syncedCount, 
+          has_more, 
+          next_cursor, 
+          shop_index: next_shop_index 
+        } 
+      };
     } catch (err: any) {
       return { success: false, message: err.message };
     }
@@ -46,5 +68,7 @@ export const orderRoutes = new Elysia({ prefix: "/orders" })
     body: t.Optional(t.Object({
       shop_id: t.Optional(t.Number()),
       days_back: t.Optional(t.Number()),
+      cursor: t.Optional(t.String()),
+      shop_index: t.Optional(t.Number()),
     }))
   });

--- a/apps/api/src/modules/shopee/shopee.route.ts
+++ b/apps/api/src/modules/shopee/shopee.route.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { getShopInfo, getItemListRaw, syncShopeeProducts, getShopeeCatalog, updateShopeeItem, updateShopeePrice, updateShopeeVariantStock, toggleShopeeItemStatus, updateShopeeModel } from "../../services/shopee.service";
 import { getShopInfoRaw } from "../../services/shopee-raw";
+import { autoMapProducts } from "../../services/master.service";
 
 export const shopeeRoutes = new Elysia({ prefix: "/shopee" })
   .get("/test-shop", async () => {
@@ -18,9 +19,12 @@ export const shopeeRoutes = new Elysia({ prefix: "/shopee" })
   })
   .get("/sync-products", async ({ query }) => {
     const shop_id = query.shop_id ? parseInt(query.shop_id as string) : undefined;
-    return await syncShopeeProducts(shop_id);
+    const result = await syncShopeeProducts(shop_id);
+    await autoMapProducts(); // Auto map after sync
+    return result;
   })
   .get("/catalog", async () => {
+    await autoMapProducts(); // Ensure mapping is up to date
     const catalog = await getShopeeCatalog();
     return { success: true, data: catalog };
   })
@@ -110,6 +114,9 @@ export const shopeeRoutes = new Elysia({ prefix: "/shopee" })
           modelName: body.model_name,
           modelSku: body.model_sku,
         });
+        if (body.model_sku !== undefined) {
+          await autoMapProducts(); // Auto map after updating SKU
+        }
         return { success: true, data: result };
       } catch (error: any) {
         set.status = 500;

--- a/apps/api/src/services/master.service.ts
+++ b/apps/api/src/services/master.service.ts
@@ -1,6 +1,6 @@
 import { eq, isNull, inArray } from "drizzle-orm";
 import { db } from "../db/client";
-import { masterProducts, products, productGroups } from "../db/schema";
+import { masterProducts, products, productGroups, masterProductVariants } from "../db/schema";
 import { 
   updateStockOnShopee, 
   updateStockOnShopeeBatch, 
@@ -73,50 +73,70 @@ export async function updateStockByMasterSku(masterProductId: number, newStock: 
     };
   }
 
-  // 4. Sync eligible variants to Shopee with retry
+  // 4. Sync eligible variants to Shopee with retry (Grouped by shopeeItemId)
   let syncCount = 0;
   const failedProducts: { id: number; error: string }[] = [];
 
-  for (const p of eligibleProducts) {
-    await db.update(products).set({ syncStatus: "pending" }).where(eq(products.id, p.id));
+  const groupedByItem = eligibleProducts.reduce((acc, p) => {
+    if (!acc[p.shopeeItemId]) acc[p.shopeeItemId] = [];
+    acc[p.shopeeItemId].push(p);
+    return acc;
+  }, {} as Record<string, typeof eligibleProducts>);
+
+  for (const itemId of Object.keys(groupedByItem)) {
+    const modelsToUpdate = groupedByItem[itemId];
+
+    // Tandai status pending
+    for (const p of modelsToUpdate) {
+      await db.update(products).set({ syncStatus: "pending" }).where(eq(products.id, p.id));
+    }
 
     let success = false;
     let lastError = "";
 
+    const payload = modelsToUpdate.map(p => ({
+      shopeeModelId: p.shopeeModelId,
+      stock: newStock
+    }));
+
     // Attempt 1
     try {
-      await updateShopeeVariantStock(p.shopeeItemId, p.shopeeModelId, newStock);
+      await updateStockOnShopeeBatch(itemId, payload);
       success = true;
     } catch (err: any) {
       lastError = err.message;
 
       // Attempt 2 (Retry x1 on transient errors)
       if (isRetryableError(lastError)) {
-        console.warn(`[MASTER SKU SYNC] sku=${master.sku} model_id=${p.shopeeModelId} failed, retrying... error=${lastError}`);
+        console.warn(`[MASTER SKU SYNC] sku=${master.sku} item_id=${itemId} failed, retrying... error=${lastError}`);
         try {
           await delay(env.syncDelayMs);
-          await updateShopeeVariantStock(p.shopeeItemId, p.shopeeModelId, newStock);
+          await updateStockOnShopeeBatch(itemId, payload);
           success = true;
         } catch (retryErr: any) {
           lastError = retryErr.message;
         }
       } else {
-        console.error(`[MASTER SKU SYNC] sku=${master.sku} model_id=${p.shopeeModelId} non-retryable error: ${lastError}`);
+        console.error(`[MASTER SKU SYNC] sku=${master.sku} item_id=${itemId} non-retryable error: ${lastError}`);
       }
     }
 
     if (success) {
-      await db.update(products)
-        .set({ syncStatus: "success", lastError: null })
-        .where(eq(products.id, p.id));
-      console.log(`[MASTER SKU SYNC] sku=${master.sku} model_id=${p.shopeeModelId} synced stock=${newStock}`);
-      syncCount++;
+      for (const p of modelsToUpdate) {
+        await db.update(products)
+          .set({ syncStatus: "success", lastError: null, shopeeStock: newStock })
+          .where(eq(products.id, p.id));
+        syncCount++;
+      }
+      console.log(`[MASTER SKU SYNC] sku=${master.sku} item_id=${itemId} synced stock=${newStock} for ${modelsToUpdate.length} models`);
     } else {
-      await db.update(products)
-        .set({ syncStatus: "failed", lastError })
-        .where(eq(products.id, p.id));
-      console.error(`[MASTER SKU SYNC] sku=${master.sku} model_id=${p.shopeeModelId} FAILED error=${lastError}`);
-      failedProducts.push({ id: p.id, error: lastError });
+      for (const p of modelsToUpdate) {
+        await db.update(products)
+          .set({ syncStatus: "failed", lastError })
+          .where(eq(products.id, p.id));
+        failedProducts.push({ id: p.id, error: lastError });
+      }
+      console.error(`[MASTER SKU SYNC] sku=${master.sku} item_id=${itemId} FAILED error=${lastError}`);
     }
 
     await delay(env.syncDelayMs);
@@ -146,6 +166,93 @@ export async function updateStockByMasterSku(masterProductId: number, newStock: 
     total_linked: allMapped.length,
     failed_models: failedProducts.length > 0 ? failedProducts.map(f => f.id) : undefined,
     failed: failedProducts.length > 0 ? failedProducts : undefined,
+  };
+}
+
+export async function updateMasterVariants(masterProductId: number, variants: any[]) {
+  const masterRows = await db.select().from(masterProducts).where(eq(masterProducts.id, masterProductId)).limit(1);
+  if (masterRows.length === 0) throw new Error("Master product not found");
+
+  // Upsert variants
+  for (const v of variants) {
+    if (v.id) {
+      await db.update(masterProductVariants)
+        .set({ sku: v.sku, name: v.name, stock: v.stock })
+        .where(eq(masterProductVariants.id, v.id));
+    } else {
+      await db.insert(masterProductVariants)
+        .values({ masterProductId, sku: v.sku, name: v.name, stock: v.stock });
+    }
+  }
+
+  // Find products matching these variant SKUs
+  const allMapped = await db.select().from(products)
+    .where(eq(products.masterProductId, masterProductId));
+
+  const groupedByItem: Record<string, { shopeeModelId: string; stock: number, dbId: number }[]> = {};
+
+  for (const v of variants) {
+    const eligibleProducts = allMapped.filter(p => p.modelSku === v.sku);
+    for (const p of eligibleProducts) {
+      if (!groupedByItem[p.shopeeItemId]) groupedByItem[p.shopeeItemId] = [];
+      groupedByItem[p.shopeeItemId].push({ shopeeModelId: p.shopeeModelId, stock: v.stock, dbId: p.id });
+    }
+  }
+
+  let syncCount = 0;
+  const failedProducts: { id: number; error: string }[] = [];
+
+  for (const itemId of Object.keys(groupedByItem)) {
+    const modelsToUpdate = groupedByItem[itemId];
+
+    for (const m of modelsToUpdate) {
+      await db.update(products).set({ syncStatus: "pending" }).where(eq(products.id, m.dbId));
+    }
+
+    const payload = modelsToUpdate.map(m => ({ shopeeModelId: m.shopeeModelId, stock: m.stock }));
+    let success = false;
+    let lastError = "";
+
+    try {
+      await updateStockOnShopeeBatch(itemId, payload);
+      success = true;
+    } catch (err: any) {
+      lastError = err.message;
+      if (isRetryableError(lastError)) {
+        console.warn(`[VARIANTS SYNC] item_id=${itemId} failed, retrying... error=${lastError}`);
+        try {
+          await delay(env.syncDelayMs);
+          await updateStockOnShopeeBatch(itemId, payload);
+          success = true;
+        } catch (retryErr: any) {
+          lastError = retryErr.message;
+        }
+      }
+    }
+
+    if (success) {
+      for (const m of modelsToUpdate) {
+        await db.update(products).set({ syncStatus: "success", lastError: null, shopeeStock: m.stock }).where(eq(products.id, m.dbId));
+        syncCount++;
+      }
+    } else {
+      for (const m of modelsToUpdate) {
+        await db.update(products).set({ syncStatus: "failed", lastError }).where(eq(products.id, m.dbId));
+        failedProducts.push({ id: m.dbId, error: lastError });
+      }
+    }
+    
+    if (Object.keys(groupedByItem).length > 1) await delay(env.syncDelayMs);
+  }
+
+  // Re-run auto mapping in case variant SKUs changed
+  await autoMapProducts();
+
+  return {
+    status: failedProducts.length === 0 ? "success" : "partial_success",
+    synced_listings: syncCount,
+    failed_listings: failedProducts.length,
+    failed_details: failedProducts,
   };
 }
 
@@ -205,6 +312,50 @@ export async function mapModelsToMaster(masterProductId: number, shopeeModelIds:
   };
 }
 
+/**
+ * Auto-maps all unmapped products based on SKU matching masterProductVariants.
+ * Call this after Shopee catalog sync or after updating variant SKUs.
+ */
+export async function autoMapProducts() {
+  const allVariants = await db.select().from(masterProductVariants);
+  const variantMap = new Map<string, number>(); // sku -> masterProductId
+  for (const v of allVariants) {
+    if (v.sku) variantMap.set(v.sku.trim().toUpperCase(), v.masterProductId);
+  }
+
+  const allProducts = await db.select().from(products);
+  let mappedCount = 0;
+  let unmappedCount = 0;
+
+  for (const p of allProducts) {
+    if (!p.modelSku) {
+      // If SKU is empty, it cannot be mapped. Clear it if previously mapped.
+      if (p.masterProductId !== null) {
+        await db.update(products).set({ masterProductId: null }).where(eq(products.id, p.id));
+        unmappedCount++;
+      }
+      continue;
+    }
+    
+    const cleanSku = p.modelSku.trim().toUpperCase();
+    const matchedMasterId = variantMap.get(cleanSku);
+    if (matchedMasterId) {
+      if (p.masterProductId !== matchedMasterId) {
+        await db.update(products).set({ masterProductId: matchedMasterId }).where(eq(products.id, p.id));
+        mappedCount++;
+      }
+    } else {
+      if (p.masterProductId !== null) {
+        await db.update(products).set({ masterProductId: null }).where(eq(products.id, p.id));
+        unmappedCount++;
+      }
+    }
+  }
+
+  console.log(`[AUTO MAP] Mapped ${mappedCount} products, unmapped ${unmappedCount} products`);
+  return { mapped: mappedCount, unmapped: unmappedCount };
+}
+
 // ─── IMPORT FROM LISTING ───────────────────────────────────────────
 
 /**
@@ -243,12 +394,39 @@ export async function importFromListing(shopeeItemId: string) {
   const masterId = (result as any).insertId as number;
   console.log(`[MASTER IMPORT] Created master id=${masterId} sku=${masterSku} name="${masterName}"`);
 
+  // 4. Import all variations under this listing as master product variants
+  const unmappedVariants = await db.select().from(products)
+    .where(eq(products.shopeeItemId, shopeeItemId));
+
+  let variantCount = 0;
+  for (const v of unmappedVariants) {
+    if (!v.modelSku) continue; // Skip variations without SKU
+    
+    // Check if variant already exists
+    const existingVar = await db.select().from(masterProductVariants)
+      .where(eq(masterProductVariants.sku, v.modelSku)).limit(1);
+      
+    if (existingVar.length === 0) {
+      await db.insert(masterProductVariants).values({
+        masterProductId: masterId,
+        sku: v.modelSku,
+        name: v.modelName || "Default",
+        stock: v.shopeeStock || 0,
+      });
+      variantCount++;
+    }
+  }
+
+  // Auto-map variations if they match
+  await autoMapProducts();
+
   return {
     status: "success",
     item_id: shopeeItemId,
     master_id: masterId,
     master_sku: masterSku,
-    message: "Master Product berhasil dibuat. Silakan mapping listing dari menu manual link."
+    variants_imported: variantCount,
+    message: `Master Product berhasil dibuat dengan ${variantCount} variasi.`
   };
 }
 
@@ -282,12 +460,16 @@ export async function listMasterProducts() {
       if (gRows.length > 0) groups.push(gRows[0]);
     }
 
+    const variants = await db.select().from(masterProductVariants)
+      .where(eq(masterProductVariants.masterProductId, m.id));
+
     result.push({
       id: m.id,
       sku: m.sku,
       name: m.name,
       stock: m.stock,
       imageUrl: groups[0]?.imageUrl || null,
+      variants: variants, // Return true master variants
       linked_models: linked,
       linked_groups: groups.map(g => ({
         id: g.id,

--- a/apps/api/src/services/order.service.ts
+++ b/apps/api/src/services/order.service.ts
@@ -5,41 +5,35 @@ import { eq } from "drizzle-orm";
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
-export async function syncShopeeOrdersService(shopId: number, daysBack: number = 15) {
+export async function syncShopeeOrdersService(shopId: number, daysBack: number = 15, cursor: string = "") {
   // Hitung rentang waktu
   const now = Math.floor(Date.now() / 1000);
   const timeFrom = now - daysBack * 24 * 60 * 60;
   const timeTo = now;
 
-  let hasMore = true;
-  let cursor = "";
   let totalSynced = 0;
-  let pageNum = 0;
 
-  while (hasMore) {
-    pageNum++;
-    // Throttle: jeda 300ms antar halaman untuk menghindari rate limit Shopee
-    if (pageNum > 1) await sleep(300);
-
-    let listRes: any;
-    // Retry saat kena rate limit (error_too_frequent / 429)
-    for (let attempt = 0; attempt < 3; attempt++) {
-      listRes = await getShopeeOrderList(shopId, timeFrom, timeTo, cursor);
-      if (listRes?.error === "error_too_frequent") {
-        console.warn(`[order-sync] Rate limited on page ${pageNum}, retrying in 2s... (attempt ${attempt + 1})`);
-        await sleep(2000);
-        continue;
-      }
-      break;
+  let listRes: any;
+  // Retry saat kena rate limit (error_too_frequent / 429)
+  for (let attempt = 0; attempt < 3; attempt++) {
+    listRes = await getShopeeOrderList(shopId, timeFrom, timeTo, cursor);
+    if (listRes?.error === "error_too_frequent") {
+      console.warn(`[order-sync] Rate limited on list fetch, retrying in 2s... (attempt ${attempt + 1})`);
+      await sleep(2000);
+      continue;
     }
+    break;
+  }
 
-    if (listRes.error) {
-      throw new Error(`Gagal menarik order list: ${listRes.message || listRes.error}`);
-    }
+  if (listRes.error) {
+    throw new Error(`Gagal menarik order list: ${listRes.message || listRes.error}`);
+  }
 
-    const orderList = listRes.response?.order_list || [];
-    if (orderList.length === 0) break;
+  const orderList = listRes.response?.order_list || [];
+  const next_cursor = listRes.response?.next_cursor || "";
+  const has_more = listRes.response?.more || false;
 
+  if (orderList.length > 0) {
     // Ekstrak SN pesanan
     const orderSns = orderList.map((o: any) => o.order_sn);
 
@@ -110,10 +104,7 @@ export async function syncShopeeOrdersService(shopId: number, daysBack: number =
         totalSynced++;
       }
     }
-
-    hasMore = listRes.response?.more || false;
-    cursor = listRes.response?.next_cursor || "";
   }
 
-  return { success: true, syncedCount: totalSynced };
+  return { success: true, syncedCount: totalSynced, has_more, next_cursor };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -37,6 +37,8 @@ export const api = {
     fetchApi(`/master/${id}`, { method: 'PATCH', body: JSON.stringify(body) }),
   masterUpdateStock: (masterProductId: number, stock: number) =>
     fetchApi('/master/update-stock', { method: 'POST', body: JSON.stringify({ master_product_id: masterProductId, stock }) }),
+  masterUpdateVariants: (masterProductId: number, variants: any[]) =>
+    fetchApi('/master/update-variants', { method: 'POST', body: JSON.stringify({ master_product_id: masterProductId, variants }) }),
   masterMap: (masterProductId: number, shopeeModelIds: string[]) =>
     fetchApi('/master/map', { method: 'POST', body: JSON.stringify({ master_product_id: masterProductId, shopee_model_ids: shopeeModelIds }) }),
   masterImport: (shopeeItemId: string) =>
@@ -56,8 +58,8 @@ export const api = {
 
   // Pesanan / Orders
   orderList: () => fetchApi<{ success: boolean; data: any[] }>('/orders'),
-  orderSync: (shopId?: number, daysBack: number = 15) => 
-    fetchApi('/orders/sync', { method: 'POST', body: JSON.stringify({ shop_id: shopId, days_back: daysBack }) }),
+  orderSync: (shopId?: number, daysBack: number = 15, cursor?: string, shopIndex?: number) => 
+    fetchApi('/orders/sync', { method: 'POST', body: JSON.stringify({ shop_id: shopId, days_back: daysBack, cursor, shop_index: shopIndex }) }),
 
   // Shopee — Otorisasi
   shopeeGetAuthUrl: () => fetchApi<{ auth_url: string }>('/shopee/auth/url'),

--- a/apps/web/src/pages/MasterProduk.tsx
+++ b/apps/web/src/pages/MasterProduk.tsx
@@ -4,7 +4,7 @@ import { Modal } from '../components/ui/Modal';
 import { useApi, useApiMutation } from '../hooks/useApi';
 import { api } from '../lib/api';
 
-import { Package, CloudUpload, Link, Search, Edit3, Book, Info, Trash2, Unlink } from 'lucide-react';
+import { Search, Edit3, Trash2, Package, Book, Info, CloudUpload } from "lucide-react";
 
 /* ── PRODUCT IMAGE PLACEHOLDER ── */
 function ProductThumb({ name, imageUrl }: { name: string; imageUrl?: string }) {
@@ -26,7 +26,7 @@ function ProductThumb({ name, imageUrl }: { name: string; imageUrl?: string }) {
 }
 
 /* ── EDIT MODAL ── */
-function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
+function EditModal({ product, onClose, onSave, saving }: any) {
   const [name, setName] = useState('');
   const [variants, setVariants] = useState<any[]>([]);
 
@@ -34,23 +34,34 @@ function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
     if (product) {
       setName(product.name || '');
       
-      const uniqueVariants = [];
-      const mskus = new Set();
-      
-      for (const v of product.linked_models || []) {
-        const msku = v.modelSku || '(Kosong)';
-        if (!mskus.has(msku)) {
-          mskus.add(msku);
-          uniqueVariants.push({
-            id: msku, // use msku as row identifier mapped to 'MSKU'
-            varName: v.modelName || 'Default',
-            msku: msku,
-            stock: v.shopeeStock ?? 0,
-            originalMsku: msku,
-          });
+      let uniqueVariants = [];
+      if (product.variants && product.variants.length > 0) {
+        uniqueVariants = product.variants.map((v: any) => ({
+          dbId: v.id, // For update
+          id: v.sku, // Unique key for UI
+          varName: v.name,
+          msku: v.sku,
+          stock: v.stock,
+          originalMsku: v.sku,
+        }));
+      } else {
+        const mskus = new Set();
+        for (const v of product.linked_models || []) {
+          const msku = v.modelSku || '(Kosong)';
+          if (!mskus.has(msku)) {
+            mskus.add(msku);
+            uniqueVariants.push({
+              dbId: null,
+              id: msku,
+              varName: v.modelName || 'Default',
+              msku: msku,
+              stock: v.shopeeStock ?? 0,
+              originalMsku: msku,
+            });
+          }
         }
       }
-      uniqueVariants.sort((a, b) => a.varName.localeCompare(b.varName));
+      uniqueVariants.sort((a: any, b: any) => a.varName.localeCompare(b.varName));
       setVariants(uniqueVariants);
     }
   }, [product]);
@@ -61,18 +72,7 @@ function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
   
   const handleFocus = (e: any) => e.target.select();
 
-  const filteredLinkedModels = useMemo(() => {
-    if (!product || !product.linked_groups) return [];
-    return product.linked_groups.map((g: any) => {
-      const variants = product.linked_models?.filter((m: any) => m.shopeeItemId === g.shopeeItemId) || [];
-      return {
-        shopeeItemId: g.shopeeItemId,
-        shopeeItemName: g.name,
-        imageUrl: g.imageUrl,
-        variants: variants.map((m: any) => ({ name: m.modelName, sku: m.shopeeModelId }))
-      };
-    });
-  }, [product]);
+
 
   if (!product) return null;
 
@@ -96,7 +96,7 @@ function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
         <div className="form-row">
           <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">Nama Produk (Global)</label>
-            <input className="form-input" value={name} onChange={e => setName(e.target.value)} disabled={saving} />
+            <input className="form-input readonly" value={name} readOnly />
           </div>
           <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">Master SKU</label>
@@ -104,32 +104,6 @@ function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
           </div>
         </div>
       </div>
-
-      {filteredLinkedModels.length > 0 && (
-         <div style={{ marginBottom: 18, border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg)' }}>
-            <div style={{ padding: '10px 14px', borderBottom: '1px solid var(--border)' }}>
-               <h4 style={{ fontSize: 12, fontWeight: 600, color: 'var(--text3)', textTransform: 'uppercase', letterSpacing: '.05em', display: 'flex', alignItems: 'center', gap: 6 }}><Link size={14} /> Produk Shopee Terhubung</h4>
-            </div>
-            <div style={{ padding: '10px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-               {filteredLinkedModels.map((group: any, idx: number) => (
-                  <div key={idx} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px', background: 'var(--bg2)', borderRadius: 6, border: '1px solid var(--border)' }}>
-                     <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
-                        <div style={{ width: 80, height: 80, borderRadius: 6, overflow: 'hidden', flexShrink: 0 }}>
-                           <ProductThumb name={group.shopeeItemName} imageUrl={group.imageUrl} />
-                        </div>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                           <div style={{ fontSize: 13, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{group.shopeeItemName || 'Listing Shopee'}</div>
-                           <div style={{ fontSize: 11.5, color: 'var(--text4)' }}>Grup Item ID: {group.shopeeItemId} • {group.variants.length} Variasi</div>
-                        </div>
-                     </div>
-                     <button type="button" className="btn btn-ghost btn-xs" style={{ color: '#DC2626', flexShrink: 0 }} onClick={() => onUnlink(group)}>
-                        <Unlink size={12} style={{ marginRight: 4 }} /> Lepas
-                     </button>
-                  </div>
-               ))}
-            </div>
-         </div>
-      )}
 
       <div>
         <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text3)', textTransform: 'uppercase', letterSpacing: '.05em', marginBottom: 10, display: 'flex', alignItems: 'center', gap: 6 }}><Edit3 size={14} /> Live Edit — MSKU & Stok Terpusat</div>
@@ -143,30 +117,42 @@ function EditModal({ product, onClose, onSave, saving, onUnlink }: any) {
               </tr>
             </thead>
             <tbody>
-              {variants.map((v) => (
-                <tr key={v.id}>
-                  <td style={{ color: 'var(--text4)', fontSize: 12.5 }}>{v.varName}</td>
-                  <td>
-                    <input className="variant-input readonly" value={v.msku} readOnly style={{ textAlign: 'left', background: 'transparent', border: 'none' }} />
-                  </td>
-                  <td>
-                    <input
-                      className="variant-input"
-                      type="number"
-                      min="0"
-                      placeholder="0"
-                      value={v.stock === 0 ? '' : v.stock}
-                      onFocus={handleFocus}
-                      onChange={e => {
-                        const valStr = e.target.value.replace(/^0+/, '');
-                        const val = valStr === '' ? 0 : parseInt(valStr, 10);
-                        updateVariant(v.id, 'stock', val);
-                      }}
-                      disabled={saving}
-                    />
-                  </td>
-                </tr>
-              ))}
+              {variants.map((v) => {
+                const isMatch = v.msku === product.sku;
+                return (
+                  <tr key={v.id}>
+                    <td style={{ color: 'var(--text4)', fontSize: 12.5 }}>
+                      {v.varName}
+                    </td>
+                    <td>
+                      <input 
+                        className="variant-input" 
+                        value={v.msku} 
+                        onChange={e => updateVariant(v.id, 'msku', e.target.value)}
+                        disabled={saving} 
+                        style={{ textAlign: 'left' }} 
+                      />
+                    </td>
+                    <td>
+                      <input
+                        className="variant-input"
+                        type="number"
+                        min="0"
+                        placeholder="0"
+                        value={v.stock === 0 ? '' : v.stock}
+                        onFocus={handleFocus}
+                        onChange={e => {
+                          const valStr = e.target.value.replace(/^0+/, '');
+                          const val = valStr === '' ? 0 : parseInt(valStr, 10);
+                          updateVariant(v.id, 'stock', val);
+                        }}
+                        disabled={saving}
+                        title={isMatch ? '' : 'Stok tidak akan di-push karena MSKU tidak cocok'}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -203,52 +189,37 @@ export function MasterProduk() {
     await api.masterImport(itemId);
   });
 
-  const linkGroupMut = useApiMutation(async (masterId: number, shopeeItemId: string) => {
-    await api.masterLinkGroup(masterId, shopeeItemId);
-  });
-
-  const unlinkMut = useApiMutation(async (shopeeItemId: string) => {
-    await api.masterUnlink(shopeeItemId);
-  });
-
   const deleteMut = useApiMutation(async (id: number) => {
     await api.masterDelete(id);
   });
 
   const [importModal, setImportModal] = useState(false);
-  const [linkModal, setLinkModal] = useState<any>(null);
-  const [unlinkConfirm, setUnlinkConfirm] = useState<any>(null);
   const [deleteModal, setDeleteModal] = useState<any>(null);
 
   const handleSaveEdit = async (product: any, newName: string, newVariants: any[]) => {
     setSavingEdit(true);
-    let successCount = 0;
     try {
       // 1. Update Master Product Name
       if (newName !== product.name) {
         await editMut.execute(product.id, product.sku, newName);
       }
 
-      // 2. Map new stocks back to models
-      const stockMap: Record<string, number> = {};
-      for (const v of newVariants) {
-        stockMap[v.originalMsku] = v.stock;
-      }
+      // 2. Update and Push Variants
+      const payloadVariants = newVariants.map(v => ({
+        id: v.dbId,
+        sku: v.msku,
+        name: v.varName,
+        stock: v.stock,
+      }));
 
-      for (const v of product.linked_models || []) {
-        const originalMsku = v.modelSku || '(Kosong)';
-        let changed = false;
-        
-        const newStock = stockMap[originalMsku];
-        if (newStock !== undefined && newStock !== (v.shopeeStock ?? 0)) {
-          await api.shopeeUpdateVariantStock(v.shopeeItemId, v.shopeeModelId, newStock);
-          changed = true;
-        }
-        
-        if (changed) successCount++;
+      const res: any = await api.masterUpdateVariants(product.id, payloadVariants);
+      
+      let toastMsg = 'Berhasil menyimpan perubahan.';
+      if (res.data?.synced_listings) {
+        toastMsg += ` ${res.data.synced_listings} variasi di-push ke Shopee.`;
       }
-
-      toast(`Berhasil menyimpan perubahan dan mem-push ${successCount} variasi ke Shopee.`, 'success');
+      
+      toast(toastMsg, 'success');
       await refetch();
       setEditTarget(null);
     } catch (err: any) {
@@ -397,10 +368,9 @@ export function MasterProduk() {
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 6, marginBottom: 8 }}>
                     <span className={`badge ${badgeClass}`}>{isMapped ? `☁ ${badgeText}` : '⚠ Unlinked'}</span>
                     <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-                      {isMapped && <span className="badge badge-purple" style={{ padding: '0 6px' }}>🔗 {models.length} Ch</span>}
-                      <button className="btn btn-ghost btn-xs" style={{ padding: '0 4px', height: 20 }} onClick={() => setLinkModal(product)} title="Tambah Tautan Shopee Baru">
-                        <Link size={12} />
-                      </button>
+                      {product.variants && product.variants.length > 0 && (
+                        <span className="badge badge-purple" style={{ padding: '0 6px' }}>{product.variants.length} SKU</span>
+                      )}
                     </div>
                   </div>
                   <div className="prod-name" title={product.name} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
@@ -425,32 +395,7 @@ export function MasterProduk() {
         </div>
       )}
 
-      <EditModal product={editTarget} onClose={() => setEditTarget(null)} onSave={handleSaveEdit} saving={savingEdit} onUnlink={(mod: any) => setUnlinkConfirm(mod)} />
-
-      <Modal open={!!unlinkConfirm} onClose={() => setUnlinkConfirm(null)} title="Konfirmasi Unlink">
-        {unlinkConfirm && (
-          <form onSubmit={async (e) => {
-            e.preventDefault();
-            try {
-              await unlinkMut.execute(unlinkConfirm.shopeeItemId);
-              toast('Listing berhasil di-unlink dari master', 'success');
-              setUnlinkConfirm(null);
-              setEditTarget(null); // Tutup modal edit untuk refresh prop product di reload selanjutnya
-              await refetch();
-            } catch (err: any) { toast(err.message || 'Gagal unlink listing', 'error'); }
-          }}>
-            <p style={{ fontSize: 13, color: 'var(--text2)', marginBottom: 16 }}>
-              Apakah Anda yakin ingin memutus koneksi listing Shopee <strong style={{ color: 'var(--text1)' }}>{unlinkConfirm.shopeeItemName || 'ini'}</strong> dari Master Produk ini?
-            </p>
-            <div className="form-actions" style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-              <button className="btn btn-ghost" type="button" onClick={() => setUnlinkConfirm(null)}>Batal</button>
-              <button className="btn btn-danger" type="submit" disabled={unlinkMut.loading}>
-                {unlinkMut.loading ? 'Memproses...' : 'Ya, Putus Koneksi'}
-              </button>
-            </div>
-          </form>
-        )}
-      </Modal>
+      <EditModal product={editTarget} onClose={() => setEditTarget(null)} onSave={handleSaveEdit} saving={savingEdit} />
 
       <Modal open={!!deleteModal} onClose={() => setDeleteModal(null)} title="Hapus Master Produk">
         {deleteModal && (
@@ -493,18 +438,6 @@ export function MasterProduk() {
           } catch (err: any) { toast(err.message || 'Gagal import listing', 'error'); }
         }}
         importLoading={importMut.loading}
-      />
-
-      <LinkGroupPicker open={!!linkModal} master={linkModal} onClose={() => setLinkModal(null)}
-        onLink={async (shopeeItemId: string) => {
-          try {
-            await linkGroupMut.execute(linkModal.id, shopeeItemId);
-            toast('Listing berhasil di-link ke master', 'success');
-            setLinkModal(null);
-            await refetch();
-          } catch (err: any) { toast(err.message || 'Gagal link listing', 'error'); }
-        }}
-        linkLoading={linkGroupMut.loading}
       />
     </div>
   );
@@ -554,55 +487,3 @@ function ImportPickerModal({ open, onClose, onImport, importLoading }: any) {
   );
 }
 
-/* ─── LINK GROUP PICKER MODAL ─── */
-function LinkGroupPicker({ open, master, onClose, onLink, linkLoading }: any) {
-  const { data: catalogData, loading } = useApi(() => open ? api.shopeeCatalog() : Promise.resolve(null), [open]);
-  const [pickerSearch, setPickerSearch] = useState('');
-
-  const catalog = catalogData?.data || [];
-  const available = catalog.filter((item: any) =>
-    item.name.toLowerCase().includes(pickerSearch.toLowerCase()) ||
-    (item.itemSku || '').toLowerCase().includes(pickerSearch.toLowerCase())
-  );
-
-  return (
-    <Modal open={open} onClose={onClose} title={`Link ke: ${master?.sku || ''}`} size="lg">
-      <div style={{ fontSize: 13, color: 'var(--text3)', marginBottom: 12, padding: '10px 14px', background: 'var(--bg3)', borderRadius: 8 }}>
-        Pilih listing produk Shopee. Semua variasi di dalamnya otomatis akan di-link ke master ini asal MSKU-nya cocok.
-      </div>
-      <div className="search-wrap" style={{ width: '100%', marginBottom: 16 }}>
-        <Search size={16} />
-        <input className="search-inp" placeholder="Cari nama produk..." value={pickerSearch} onChange={(e) => setPickerSearch(e.target.value)} />
-      </div>
-      {loading ? (
-        <div style={{ textAlign: 'center', padding: 20 }}>Memuat katalog...</div>
-      ) : (
-        <div style={{ maxHeight: 400, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {available.map((item: any) => {
-             const isMapped = item.mappedVariants > 0;
-             return (
-               <div key={item.shopeeItemId} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 12, border: '1px solid var(--border)', borderRadius: 8 }}>
-                   <div style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 6, overflow: 'hidden' }}>
-                      <ProductThumb name={item.name} imageUrl={item.imageUrl} />
-                   </div>
-                   <div style={{ flex: 1, minWidth: 0 }}>
-                      <div className="prod-name" style={{ fontSize: 13, color: isMapped ? 'var(--text4)' : 'var(--text1)' }}>{item.name}</div>
-                      <div style={{ fontSize: 11, color: 'var(--text4)' }}>
-                         {item.totalVariants} variasi {isMapped && <span style={{ color: '#DC2626' }}> • Ter-link ke master lain</span>}
-                      </div>
-                   </div>
-                   {isMapped ? (
-                      <button className="btn btn-ghost btn-sm" disabled>Sudah Mapped</button>
-                   ) : (
-                      <button className="btn btn-primary btn-sm" onClick={() => onLink(item.shopeeItemId)} disabled={linkLoading}>
-                         Link Item Ini
-                      </button>
-                   )}
-               </div>
-             )
-          })}
-        </div>
-      )}
-    </Modal>
-  );
-}

--- a/apps/web/src/pages/PesananSaya.tsx
+++ b/apps/web/src/pages/PesananSaya.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useToast } from '../components/ui/Toast';
-import { useApi, useApiMutation } from '../hooks/useApi';
+import { useApi } from '../hooks/useApi';
 import { api } from '../lib/api';
 import { Package, RefreshCw, Search, Truck } from 'lucide-react';
 import { format } from 'date-fns';
@@ -154,21 +154,41 @@ export function PesananSaya() {
   const [subFilter, setSubFilter]     = useState<SubFilter>('ALL');
   const [search, setSearch]           = useState('');
 
-  const syncMut = useApiMutation(async () => {
-    return await api.orderSync();
-  });
+  const [syncProgress, setSyncProgress] = useState<{ total: number, page: number } | null>(null);
 
   const handleSync = async () => {
     setSyncing(true);
-    toast('Memulai penarikan data pesanan Shopee (15 hari terakhir)...', 'info');
+    setSyncProgress({ total: 0, page: 1 });
+    toast('Memulai penarikan pesanan Shopee...', 'info');
+    
+    let currentCursor = '';
+    let totalSynced = 0;
+    let pageCount = 1;
+    let currentShopIndex = 0;
+
     try {
-      const res = await syncMut.execute();
-      toast(res.message || 'Berhasil menarik pesanan', 'success');
-      await refetch();
+      while (true) {
+        const res: any = await api.orderSync(undefined, 15, currentCursor, currentShopIndex);
+        const fetched = res.data?.fetched || 0;
+        totalSynced += fetched;
+        setSyncProgress({ total: totalSynced, page: pageCount });
+        
+        if (!res.data?.has_more) {
+          toast(`Berhasil menarik total ${totalSynced} pesanan`, 'success');
+          break;
+        }
+        
+        currentCursor = res.data.next_cursor;
+        currentShopIndex = res.data.shop_index || 0;
+        pageCount++;
+        await new Promise(r => setTimeout(r, 500)); // Delay between pages
+      }
     } catch (err: any) {
-      toast(err.message || 'Gagal menarik pesanan', 'error');
+      toast(err.message || 'Terputus. Silakan klik tarik lagi untuk resume penarikan.', 'error');
     } finally {
       setSyncing(false);
+      setSyncProgress(null);
+      await refetch();
     }
   };
 
@@ -208,8 +228,8 @@ export function PesananSaya() {
     return matchMain && matchSearch;
   });
 
-  const badgeDot = (count: number, color: string) =>
-    count > 0 ? <span style={{ marginLeft: 4, background: color, color: '#fff', fontSize: 10, padding: '0 5px', borderRadius: 10, fontWeight: 700 }}>{count}</span> : null;
+  const badgeDot = (count: number, badgeCls: string) =>
+    count > 0 ? <span className={`badge ${badgeCls}`} style={{ marginLeft: 6, padding: '2px 6px', fontSize: 10 }}>{count}</span> : null;
 
   return (
     <div className="wms-page animate-fade-in">
@@ -221,7 +241,7 @@ export function PesananSaya() {
         <div className="page-actions">
           <button className="btn btn-shopee" onClick={handleSync} disabled={syncing}>
             {syncing ? <RefreshCw size={14} className="spin" /> : <RefreshCw size={14} />}
-            {syncing ? 'Menarik...' : 'Tarik Pesanan (15 Hari)'}
+            {syncing ? `Menarik... (Hal ${syncProgress?.page || 1})` : 'Tarik Pesanan'}
           </button>
         </div>
       </div>
@@ -257,21 +277,21 @@ export function PesananSaya() {
               className={`filter-tab ${mainFilter === 'UNPAID' ? 'active' : ''}`}
               onClick={() => handleMainFilter('UNPAID')}
             >
-              Belum Bayar{badgeDot(countUnpaid, '#F59E0B')}
+              Belum Bayar{badgeDot(countUnpaid, 'badge-orange')}
             </button>
 
             <button
               className={`filter-tab ${mainFilter === 'NEED_SHIP' ? 'active' : ''}`}
               onClick={() => handleMainFilter('NEED_SHIP')}
             >
-              Perlu Dikirim{badgeDot(countNeedShip, '#3B82F6')}
+              Perlu Dikirim{badgeDot(countNeedShip, 'badge-primary')}
             </button>
 
             <button
               className={`filter-tab ${mainFilter === 'SHIPPED' ? 'active' : ''}`}
               onClick={() => handleMainFilter('SHIPPED')}
             >
-              Dikirim{badgeDot(countShipped, '#8B5CF6')}
+              Dikirim{badgeDot(countShipped, 'badge-purple')}
             </button>
 
             <button

--- a/apps/web/src/pages/ProdukChannel.tsx
+++ b/apps/web/src/pages/ProdukChannel.tsx
@@ -38,6 +38,8 @@ function EditModal({ product, onClose, onSave, saving }: any) {
         msku: v.modelSku || '',
         stock: v.shopeeStock ?? 0,
         origPrice: v.price,
+        isMapped: v.isMapped,
+        masterSku: v.master?.sku,
       }));
       uniqueVariants.sort((a: any, b: any) => a.varName.localeCompare(b.varName));
       setVariants(uniqueVariants);
@@ -97,9 +99,14 @@ function EditModal({ product, onClose, onSave, saving }: any) {
               </tr>
             </thead>
             <tbody>
-              {variants.map((v) => (
+              {variants.map((v) => {
+                const mismatch = !v.isMapped;
+                return (
                 <tr key={v.id}>
-                  <td style={{ color: 'var(--text3)', fontSize: 12.5 }}>{v.varName}</td>
+                  <td style={{ color: 'var(--text3)', fontSize: 12.5 }}>
+                    {v.varName}
+                    {mismatch && <div style={{ fontSize: 10, color: '#DC2626', marginTop: 2 }}>SKU variasi belum ter-mapping ke Master Produk</div>}
+                  </td>
                   <td>
                     <input
                       className="variant-input"
@@ -135,7 +142,8 @@ function EditModal({ product, onClose, onSave, saving }: any) {
                     />
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -345,7 +353,16 @@ export function ProdukChannel() {
       ) : (
         <div className="product-grid">
           {filtered.map(product => {
-            const isMapped = product.mappedVariants === product.totalVariants && product.totalVariants > 0;
+            let badgeClass = 'badge-red';
+            let badgeText = 'Unlinked';
+            
+            if (product.mappedVariants === product.totalVariants && product.totalVariants > 0) {
+              badgeClass = 'badge-green';
+              badgeText = 'Linked';
+            } else if (product.mappedVariants > 0 && product.mappedVariants < product.totalVariants) {
+              badgeClass = 'badge-orange';
+              badgeText = 'Sebagian';
+            }
             const prices = (product.variants || []).map((v: any) => v.price).filter((p: number) => p > 0);
             let priceStr = '';
             if (prices.length > 0) {
@@ -364,9 +381,9 @@ export function ProdukChannel() {
               <div key={product.shopeeItemId} className="prod-card">
                 <ProductThumb name={product.name || ''} imageUrl={product.imageUrl} />
                 <div className="prod-body">
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 6, marginBottom: 6 }}>
-                    <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--shopee)' }}>{priceStr}</span>
-                    <span className={`badge ${isMapped ? 'badge-blue' : 'badge-yellow'}`}>{isMapped ? `Ter-link ${product.mappedVariants}` : 'Unlinked'}</span>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 6, marginBottom: 6, height: 38 }}>
+                    <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--shopee)', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{priceStr}</span>
+                    <span className={`badge ${badgeClass}`} style={{ flexShrink: 0 }}>{badgeText}</span>
                   </div>
                   <div className="prod-name" title={product.name}>{product.name}</div>
                   <div className="prod-sku">{product.itemSku || product.shopeeItemId}</div>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -216,6 +216,7 @@ h1, h2, h3, h4, h5, h6 { line-height: 1.3; }
 .dark .badge-purple  { background: rgba(126, 34, 206, 0.2); color: #C084FC; }
 .dark .badge-gray    { background: var(--bg2); color: var(--text3); border-color: var(--border); }
 .dark .badge-orange  { background: rgba(194, 65, 12, 0.2); color: #FB923C; }
+.dark .badge-primary { background: rgba(29, 78, 216, 0.2); color: #60A5FA; }
 .badge-dot::before { content: ''; display: inline-block; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
 
 /* ── TABLE ── */
@@ -277,10 +278,10 @@ h1, h2, h3, h4, h5, h6 { line-height: 1.3; }
 .prod-body { padding: 12px 16px; display: flex; flex-direction: column; flex: 1; }
 .prod-name { font-size: 13.5px; font-weight: 500; color: var(--text1); margin-bottom: 6px; line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
-  min-height: 38px; }
-.prod-sku  { font-size: 11px; color: var(--text4); font-family: monospace; margin-bottom: 4px; min-height: 16px; }
-.prod-shop { font-size: 11.5px; color: var(--text3); font-weight: 500; min-height: 18px; }
-.prod-meta { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; min-height: 22px; }
+  height: 38px; }
+.prod-sku  { font-size: 11px; color: var(--text4); font-family: monospace; margin-bottom: 4px; height: 16px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.prod-shop { font-size: 11.5px; color: var(--text3); font-weight: 500; height: 18px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.prod-meta { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; height: 22px; }
 .prod-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: 8px; border-top: 1px solid var(--bg3); }
 
 /* ── SHOP CARDS ── */


### PR DESCRIPTION
## Changes
- Removed manual product linking and transition completely to automated SKU-based mapping.
- Added background sync and sweeping to immediately reflect mapping updates upon Shopee Catalog reload.
- Normalized SKUs using trim() and toUpperCase() to ensure exact matches without casing issues.
- Updated Product Channel card badges with correct status (Linked, Unlinked, Sebagian).
- Updated Master Product card to display SKU count (e.g., 2 SKU) instead of inaccurate Channel counts.
- Fixed inaccurate Master Product listings by triggering auto-map seamlessly after Shopee imports.