### PR TITLE
Deteksi pesanan tertunda + sticky header Laporan + gabung toggle cetak label

### DIFF
--- a/apps/api/drizzle/0034_order_ship_by_date.sql
+++ b/apps/api/drizzle/0034_order_ship_by_date.sql
@@ -1,0 +1,7 @@
+-- 0034_order_ship_by_date.sql
+-- Capture Shopee's ship-by deadline so the app can detect "tertunda" (held)
+-- orders. Shopee reports held orders with order_status = READY_TO_SHIP but
+-- ship_by_date = 0 (the seller cannot arrange shipment yet, typically during
+-- peak-promo windows). A non-zero value means the order is genuinely shippable.
+ALTER TABLE `shopee_orders`
+  ADD COLUMN `ship_by_date` INT NOT NULL DEFAULT 0;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780400000000,
       "tag": "0033_master_image_url",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "5",
+      "when": 1780500000000,
+      "tag": "0034_order_ship_by_date",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -78,6 +78,10 @@ export const shopeeOrders = mysqlTable("shopee_orders", {
   buyerUsername: varchar("buyer_username", { length: 255 }),
   shippingCarrier: varchar("shipping_carrier", { length: 100 }),
   trackingNumber: varchar("tracking_number", { length: 100 }),
+  // Shopee ship-by deadline (unix seconds). 0 means Shopee is holding the order
+  // ("tertunda"/Menunggu) — it cannot be processed yet even though order_status
+  // is READY_TO_SHIP. A non-zero value means the order is genuinely shippable.
+  shipByDate: int("ship_by_date").notNull().default(0),
   labelPrinted: int("label_printed").notNull().default(0), // 0 = belum dicetak, 1 = sudah dicetak
   labelPrintedAt: timestamp("label_printed_at"), // Waktu label terakhir dicetak
   payTime: timestamp("pay_time"),

--- a/apps/api/src/services/background-sync.service.ts
+++ b/apps/api/src/services/background-sync.service.ts
@@ -741,6 +741,20 @@ class BackgroundSyncService {
                 finalStatus = 'SHIPPED';
               }
 
+              // A "tertunda" (held) order flips to shippable WITHOUT a status
+              // change: it stays READY_TO_SHIP and only ship_by_date goes from 0
+              // to a real timestamp. So we must refresh ship_by_date even when
+              // the status is unchanged, otherwise the "Tertunda" badge would
+              // never clear via background sync (only via manual sync).
+              const apiShipByDate = order.ship_by_date ?? existing.shipByDate;
+              if (finalStatus === oldStatus && apiShipByDate !== existing.shipByDate) {
+                await db.update(shopeeOrders)
+                  .set({ shipByDate: apiShipByDate, updatedAt: new Date() })
+                  .where(eq(shopeeOrders.orderSn, order.order_sn));
+                console.log(`[background-sync] Job "${jobName}": 🔄 ${order.order_sn} ship_by_date ${existing.shipByDate} → ${apiShipByDate} (status unchanged)`);
+                totalUpdated++;
+              }
+
               // Only update if status actually changed AND is not a downgrade
               // CRITICAL: CANCELLED has priority 99, so it will always override PROCESSED
               if (finalStatus !== oldStatus) {
@@ -763,6 +777,7 @@ class BackgroundSyncService {
                       orderStatus: finalStatus,
                       shippingCarrier,
                       totalAmount: order.total_amount ? Math.round(order.total_amount) : existing.totalAmount,
+                      shipByDate: order.ship_by_date ?? existing.shipByDate,
                       updatedAt: new Date(),
                     })
                     .where(eq(shopeeOrders.orderSn, order.order_sn));

--- a/apps/api/src/services/order.service.ts
+++ b/apps/api/src/services/order.service.ts
@@ -216,6 +216,9 @@ export async function syncShopeeOrdersIncremental(
           buyerUsername: order.buyer_username || "",
           shippingCarrier,
           trackingNumber,
+          // Shopee ship-by deadline (unix seconds). 0 = order is held ("tertunda"):
+          // READY_TO_SHIP but not yet processable. Non-zero = genuinely shippable.
+          shipByDate: order.ship_by_date ?? 0,
           payTime: order.pay_time ? new Date(order.pay_time * 1000) : null,
           createTime: new Date(order.create_time * 1000),
           updatedAt: new Date(),

--- a/apps/web/src/components/settings/StaffPermissions.tsx
+++ b/apps/web/src/components/settings/StaffPermissions.tsx
@@ -14,12 +14,23 @@ import { Icon } from '../ui/Icon';
 
 /** Friendly labels + descriptions for configurable features. */
 const FEATURE_META: Record<string, { label: string; desc: string; icon: string }> = {
-  orders: { label: 'Pesanan Saya', desc: 'Lihat dan proses pesanan', icon: 'orders' },
+  orders: { label: 'Pesanan Saya', desc: 'Lihat, proses pesanan & cetak label', icon: 'orders' },
   cetak_label: { label: 'Cetak Label', desc: 'Cetak label pengiriman', icon: 'orders' },
   master_produk: { label: 'Master Produk', desc: 'Kelola data master produk & HPP', icon: 'master' },
   produk_channel: { label: 'Produk Channel', desc: 'Kelola listing produk channel', icon: 'products' },
   laporan_keuangan: { label: 'Laporan Keuangan', desc: 'Lihat laporan laba rugi', icon: 'reports' },
 };
+
+/**
+ * Features that are not shown as their own row because they're an inseparable
+ * part of another feature. `cetak_label` lives inside the Pesanan Saya page
+ * (the batch "Cetak Label" action), so it's folded into the `orders` toggle:
+ * flipping Pesanan Saya flips cetak_label to match.
+ */
+const HIDDEN_FEATURES = new Set<string>(['cetak_label']);
+
+/** Features that should mirror the state of `orders` when it's toggled. */
+const ORDERS_LINKED_FEATURES = ['cetak_label'] as const;
 
 interface Row {
   feature: string;
@@ -58,18 +69,23 @@ export function StaffPermissions() {
     if (!current) return;
     const nextEnabled = !current.enabled;
 
+    // `cetak_label` is part of the Pesanan Saya page, so the `orders` toggle
+    // controls both. Flipping orders flips its linked features to match.
+    const linked = feature === 'orders' ? [...ORDERS_LINKED_FEATURES] : [];
+    const affected = new Set<string>([feature, ...linked]);
+
     // Optimistic update.
-    setRows((prev) => prev.map((r) => (r.feature === feature ? { ...r, enabled: nextEnabled } : r)));
+    setRows((prev) => prev.map((r) => (affected.has(r.feature) ? { ...r, enabled: nextEnabled } : r)));
     setSavingFeature(feature);
     setError(null);
 
     try {
-      const payload = rows.map((r) => (r.feature === feature ? { ...r, enabled: nextEnabled } : r));
+      const payload = rows.map((r) => (affected.has(r.feature) ? { ...r, enabled: nextEnabled } : r));
       const res = await api.permissionsUpdate(payload);
       setRows(res.permissions);
     } catch {
       // Revert on error.
-      setRows((prev) => prev.map((r) => (r.feature === feature ? { ...r, enabled: current.enabled } : r)));
+      setRows((prev) => prev.map((r) => (affected.has(r.feature) ? { ...r, enabled: current.enabled } : r)));
       setError('Gagal menyimpan perubahan. Coba lagi.');
     } finally {
       setSavingFeature(null);
@@ -109,7 +125,7 @@ export function StaffPermissions() {
       )}
 
       <div className="card" style={{ padding: '4px 0' }}>
-        {rows.map((row, idx) => {
+        {rows.filter((row) => !HIDDEN_FEATURES.has(row.feature)).map((row, idx) => {
           const meta = FEATURE_META[row.feature] ?? {
             label: row.feature,
             desc: '',

--- a/apps/web/src/pages/LaporanKeuangan.css
+++ b/apps/web/src/pages/LaporanKeuangan.css
@@ -274,13 +274,18 @@
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow-x: auto;
+  /* Both axes scroll inside the wrapper so sticky <th> is anchored here
+     instead of the page-level scroll container. Capping the height ensures
+     the table can scroll vertically and the header can actually stick. */
+  overflow: auto;
+  max-height: calc(100vh - 280px);
 }
 
 .laporan-table {
   width: 100%;
   min-width: 900px;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 0.8125rem;
 }
 
@@ -290,11 +295,17 @@
   font-weight: 600;
   color: var(--text3);
   background: var(--bg2);
-  border-bottom: 1px solid var(--border);
   white-space: nowrap;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+  /* Sticky header: stays visible while the tbody scrolls underneath.
+     `border-bottom` on a sticky <th> can disappear during scroll in some
+     browsers, so we paint the divider via box-shadow instead. */
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  box-shadow: inset 0 -1px 0 var(--border);
 }
 
 .laporan-table td {

--- a/apps/web/src/pages/PesananSaya.tsx
+++ b/apps/web/src/pages/PesananSaya.tsx
@@ -79,6 +79,12 @@ function OrderCard({
   const isProcessed = order.orderStatus === 'PROCESSED';
   const isLabelPrinted = order.labelPrinted === 1;
 
+  // Shopee holds some READY_TO_SHIP orders ("tertunda"/Menunggu): they report
+  // shipByDate === 0 and cannot be processed yet. Detect that so we can disable
+  // "Atur Pengiriman" and show a "Tertunda" label instead of letting the staff
+  // hit a Shopee error. A genuinely shippable order has a non-zero shipByDate.
+  const isHeld = isReadyToShip && (order.shipByDate ?? 0) === 0;
+
   // Show "Lihat Rincian" only in the "Perlu Dikirim" tab for READY_TO_SHIP / PROCESSED orders
   // (Requirements 1.1, 1.2, 1.3)
   const showLihatRincian =
@@ -102,7 +108,14 @@ function OrderCard({
               type="checkbox"
               checked={isSelected}
               onChange={() => onToggleSelection(order.orderSn)}
-              style={{ width: 14, height: 14, cursor: 'pointer' }}
+              disabled={isHeld}
+              title={isHeld ? 'Pesanan tertunda Shopee, belum bisa diproses' : undefined}
+              style={{
+                width: 14,
+                height: 14,
+                cursor: isHeld ? 'not-allowed' : 'pointer',
+                opacity: isHeld ? 0.4 : 1,
+              }}
             />
           )}
           {isProcessed && (
@@ -218,19 +231,32 @@ function OrderCard({
               <div style={{ textAlign: 'center' }}>
                 {idx === 0 && order.orderStatus === 'READY_TO_SHIP' ? (
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-                    <button
-                      onClick={() => onShipOrder(order.orderSn)}
-                      style={{
-                        padding: '6px 12px', borderRadius: 6, border: 'none',
-                        fontSize: 12, fontWeight: 600, cursor: 'pointer',
-                        background: 'var(--accent)', color: 'var(--accent-f)',
-                        display: 'flex', alignItems: 'center', gap: 6,
-                        justifyContent: 'center', transition: 'all .15s',
+                    {isHeld ? (
+                      <span style={{
+                        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                        padding: '6px 12px', borderRadius: 6,
+                        fontSize: 12, fontWeight: 600,
+                        background: 'var(--bg3)', color: 'var(--text4)',
+                        cursor: 'not-allowed', whiteSpace: 'nowrap',
                       }}
-                    >
-                      <Truck size={12} />
-                      Atur Pengiriman
-                    </button>
+                      title="Pesanan tertunda Shopee, belum bisa diproses">
+                        Tertunda
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => onShipOrder(order.orderSn)}
+                        style={{
+                          padding: '6px 12px', borderRadius: 6, border: 'none',
+                          fontSize: 12, fontWeight: 600, cursor: 'pointer',
+                          background: 'var(--accent)', color: 'var(--accent-f)',
+                          display: 'flex', alignItems: 'center', gap: 6,
+                          justifyContent: 'center', transition: 'all .15s',
+                        }}
+                      >
+                        <Truck size={12} />
+                        Atur Pengiriman
+                      </button>
+                    )}
                     {showLihatRincian && (
                       <LihatRincianButton
                         orderSn={order.orderSn}
@@ -307,19 +333,32 @@ function OrderCard({
             <div style={{ textAlign: 'center' }}>
               {order.orderStatus === 'READY_TO_SHIP' ? (
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-                  <button
-                    onClick={() => onShipOrder(order.orderSn)}
-                    style={{
-                      padding: '6px 12px', borderRadius: 6, border: 'none',
-                      fontSize: 12, fontWeight: 600, cursor: 'pointer',
-                      background: 'var(--accent)', color: 'var(--accent-f)',
-                      display: 'flex', alignItems: 'center', gap: 6,
-                      justifyContent: 'center', transition: 'all .15s',
+                  {isHeld ? (
+                    <span style={{
+                      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                      padding: '6px 12px', borderRadius: 6,
+                      fontSize: 12, fontWeight: 600,
+                      background: 'var(--bg3)', color: 'var(--text4)',
+                      cursor: 'not-allowed', whiteSpace: 'nowrap',
                     }}
-                  >
-                    <Truck size={12} />
-                    Atur Pengiriman
-                  </button>
+                    title="Pesanan tertunda Shopee, belum bisa diproses">
+                      Tertunda
+                    </span>
+                  ) : (
+                    <button
+                      onClick={() => onShipOrder(order.orderSn)}
+                      style={{
+                        padding: '6px 12px', borderRadius: 6, border: 'none',
+                        fontSize: 12, fontWeight: 600, cursor: 'pointer',
+                        background: 'var(--accent)', color: 'var(--accent-f)',
+                        display: 'flex', alignItems: 'center', gap: 6,
+                        justifyContent: 'center', transition: 'all .15s',
+                      }}
+                    >
+                      <Truck size={12} />
+                      Atur Pengiriman
+                    </button>
+                  )}
                   {showLihatRincian && (
                     <LihatRincianButton
                       orderSn={order.orderSn}
@@ -474,8 +513,12 @@ export function PesananSaya() {
   };
 
   const selectAllReadyToShip = () => {
-    const readyToShipOrders = filtered.filter(o => o.orderStatus === 'READY_TO_SHIP');
-    const allSelected = readyToShipOrders.every(o => selectedOrders.includes(o.orderSn));
+    // Exclude held ("tertunda") orders — shipByDate === 0 means Shopee won't let
+    // them be processed yet, so they must not be batch-selectable.
+    const readyToShipOrders = filtered.filter(
+      o => o.orderStatus === 'READY_TO_SHIP' && (o.shipByDate ?? 0) !== 0
+    );
+    const allSelected = readyToShipOrders.length > 0 && readyToShipOrders.every(o => selectedOrders.includes(o.orderSn));
     
     if (allSelected) {
       // Deselect all ready to ship orders
@@ -1084,7 +1127,7 @@ export function PesananSaya() {
                   type="checkbox"
                   checked={
                     filtered.length > 0 &&
-                    filtered.filter(o => o.orderStatus === 'READY_TO_SHIP').every(o => selectedOrders.includes(o.orderSn)) &&
+                    filtered.filter(o => o.orderStatus === 'READY_TO_SHIP' && (o.shipByDate ?? 0) !== 0).every(o => selectedOrders.includes(o.orderSn)) &&
                     filtered.filter(o => o.orderStatus === 'PROCESSED').every(o => selectedLabelOrders.includes(o.orderSn))
                   }
                   onChange={() => {
@@ -1100,8 +1143,8 @@ export function PesananSaya() {
               {countRts > 0 && mainFilter === 'NEED_SHIP' && subFilter === 'READY_TO_SHIP' && (
                 <input
                   type="checkbox"
-                  checked={filtered.filter(o => o.orderStatus === 'READY_TO_SHIP').length > 0 && 
-                           filtered.filter(o => o.orderStatus === 'READY_TO_SHIP').every(o => selectedOrders.includes(o.orderSn))}
+                  checked={filtered.filter(o => o.orderStatus === 'READY_TO_SHIP' && (o.shipByDate ?? 0) !== 0).length > 0 && 
+                           filtered.filter(o => o.orderStatus === 'READY_TO_SHIP' && (o.shipByDate ?? 0) !== 0).every(o => selectedOrders.includes(o.orderSn))}
                   onChange={selectAllReadyToShip}
                   style={{ width: 12, height: 12, cursor: 'pointer' }}
                   title="Pilih semua pesanan yang perlu diproses"


### PR DESCRIPTION
Mendeteksi pesanan tertunda (held) dari Shopee dan otomatis memperbaruinya menjadi siap dikirim saat sudah bisa diproses.

## Perubahan
- **Deteksi tertunda**: tambah kolom ship_by_date di shopee_orders. Order READY_TO_SHIP dengan ship_by_date=0 dianggap tertunda.
- **UI Pesanan Saya**: tombol Atur Pengiriman diganti label Tertunda (non-klik), checkbox batch dikecualikan.
- **Auto-update**: background stuck-orders job kini merefresh ship_by_date walau status tidak berubah, sehingga label Tertunda otomatis hilang ketika Shopee membuka order.
- **Laporan Keuangan**: header tabel sticky saat scroll.
- **Akses Staff**: toggle cetak_label digabung ke toggle Pesanan Saya.

## Verifikasi
- Build web (Vite) hijau.
- Deteksi terverifikasi dengan data nyata: 3 order tertunda vs 1 order shippable.