### PR TITLE
chore(profit): hapus profitShops API + route /profit/shops yang tak terpakai

### DIFF
--- a/apps/api/src/modules/profit/profit.route.ts
+++ b/apps/api/src/modules/profit/profit.route.ts
@@ -4,7 +4,6 @@
  * Defines Elysia routes for profit analytics:
  *   GET /profit/summary    → getProfitSummary
  *   GET /profit/orders     → getOrderProfitList
- *   GET /profit/shops      → getShopPerformance
  *   GET /profit/products   → getProductPerformance
  *   GET /profit/deductions → getShopeeDeductions
  *
@@ -15,7 +14,6 @@ import { Elysia, t } from "elysia";
 import {
   getProfitSummary,
   getOrderProfitList,
-  getShopPerformance,
   getProductPerformance,
   getShopeeDeductions,
 } from "./profit.service";
@@ -164,42 +162,6 @@ export const profitRoutes = new Elysia({ prefix: "/profit" })
         shop_id: t.Optional(t.String()),
         page: t.Optional(t.String()),
         limit: t.Optional(t.String()),
-      }),
-    },
-  )
-
-  // ─── GET /profit/shops ────────────────────────────────────────────────────
-  .get(
-    "/shops",
-    async ({ query, set }) => {
-      try {
-        const dateError = validateDateRange(query.start_date, query.end_date);
-        if (dateError) {
-          set.status = 400;
-          return { success: false, message: dateError };
-        }
-
-        const validSortBy = ["revenue", "netProfit", "profitMarginPercent", "orderCount"] as const;
-        if (query.sort_by !== undefined && !validSortBy.includes(query.sort_by as typeof validSortBy[number])) {
-          set.status = 400;
-          return { success: false, message: "Parameter sort_by tidak valid" };
-        }
-
-        return await getShopPerformance({
-          startDate: query.start_date!,
-          endDate: query.end_date!,
-          sortBy: query.sort_by,
-        });
-      } catch (err) {
-        set.status = 500;
-        return { success: false, message: "Terjadi kesalahan pada server" };
-      }
-    },
-    {
-      query: t.Object({
-        start_date: t.Optional(t.String()),
-        end_date: t.Optional(t.String()),
-        sort_by: t.Optional(t.String()),
       }),
     },
   )

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -364,10 +364,6 @@ export const api = {
       },
     };
   },
-  profitShops: (startDate: string, endDate: string, sortBy = 'revenue') => {
-    const params = new URLSearchParams({ start_date: startDate, end_date: endDate, sort_by: sortBy });
-    return fetchApi(`/profit/shops?${params}`);
-  },
   profitProducts: (startDate: string, endDate: string, shopId?: number, groupBy = 'msku', sortBy = 'netProfit') => {
     const params = new URLSearchParams({ start_date: startDate, end_date: endDate, group_by: groupBy, sort_by: sortBy });
     if (shopId) params.set('shop_id', String(shopId));


### PR DESCRIPTION
Setelah tab Per Toko dihapus, endpoint shop-performance dan client frontend-nya tidak dipakai lagi.

- Hapus api.profitShops di apps/web/src/lib/api.ts
- Hapus route GET /profit/shops + import getShopPerformance di profit.route.ts
- Logic service/calculator (getShopPerformance, aggregateShopPerformance) dibiarkan karena masih dicakup property test.