### PR TITLE
fix(ads): biaya iklan akurat — sync force-refresh, bukan cache doang

### DIFF
--- a/apps/api/src/scripts/backfill-ads-expense.ts
+++ b/apps/api/src/scripts/backfill-ads-expense.ts
@@ -11,9 +11,12 @@
  * hari oleh service supaya patuh limit Shopee Ads daily-performance API.
  *
  * Usage:
- *   bun run apps/api/src/scripts/backfill-ads-expense.ts [days]
+ *   bun run apps/api/src/scripts/backfill-ads-expense.ts [days] [--force]
  *
- *   - days   : opsional, jumlah hari ke belakang (default: 180)
+ *   - days    : opsional, jumlah hari ke belakang (default: 180)
+ *   - --force : opsional, paksa tarik ulang dari Shopee (timpa cache lama).
+ *               Gunakan ini untuk mengoreksi data lama yang sudah "beku" di
+ *               cache padahal Shopee sudah merevisi angkanya.
  *
  * Catatan:
  *   - Shopee Ads API hanya menyimpan data ~6 bulan (180 hari) ke belakang.
@@ -47,10 +50,13 @@ function wibDateOffset(daysBack: number): string {
 // ─── Main ─────────────────────────────────────────────────────
 
 async function main() {
-  const argDays = Number.parseInt(process.argv[2] ?? "180", 10);
+  const args = process.argv.slice(2);
+  const forceRefresh = args.includes("--force");
+  const daysArg = args.find((a) => !a.startsWith("--"));
+  const argDays = Number.parseInt(daysArg ?? "180", 10);
   if (!Number.isInteger(argDays) || argDays < 1 || argDays > 365) {
     console.error(
-      `[backfill-ads] Invalid days argument "${process.argv[2]}" — must be integer 1..365`
+      `[backfill-ads] Invalid days argument "${daysArg}" — must be integer 1..365`
     );
     process.exit(1);
   }
@@ -68,6 +74,7 @@ async function main() {
   console.log(`[backfill-ads] Start date    : ${startDate}`);
   console.log(`[backfill-ads] End date      : ${endDate}  (today excluded)`);
   console.log(`[backfill-ads] Days to cover : ${argDays}`);
+  console.log(`[backfill-ads] Force refresh : ${forceRefresh ? "YES (overwrite cache)" : "no (cache-first)"}`);
   console.log("");
 
   // Ambil daftar toko
@@ -97,7 +104,7 @@ async function main() {
     const startedAt = Date.now();
 
     try {
-      const total = await getShopExpense(shop.shopId, startDate, endDate);
+      const total = await getShopExpense(shop.shopId, startDate, endDate, { forceRefresh });
       const duration = Date.now() - startedAt;
       totalsPerShop.push({
         shopId: shop.shopId,

--- a/apps/api/src/services/ads-expense.service.ts
+++ b/apps/api/src/services/ads-expense.service.ts
@@ -762,7 +762,8 @@ function delay(ms: number): Promise<void> {
 export async function getShopExpense(
   shopId: number,
   startDate: WibDate,
-  endDate: WibDate
+  endDate: WibDate,
+  options: { forceRefresh?: boolean } = {}
 ): Promise<number> {
   // Validate inputs
   if (!Number.isInteger(shopId) || shopId <= 0) {
@@ -789,7 +790,18 @@ export async function getShopExpense(
     todayWib
   );
   
-  const { freshDates, needFetchDates, beyondCutoffDates } = classification;
+  let { freshDates, needFetchDates } = classification;
+  const { beyondCutoffDates } = classification;
+
+  // Force refresh: Shopee adjusts ad spend retroactively for several days, so a
+  // cache-first read can lag behind Seller Center. When the caller asks for a
+  // forced refresh (e.g. the scheduled ads sync), re-fetch every in-window date
+  // instead of trusting the cache. Dates beyond the 6-month cutoff stay
+  // cache-only because Shopee no longer serves data that old.
+  if (options.forceRefresh && freshDates.length > 0) {
+    needFetchDates = [...needFetchDates, ...freshDates].sort();
+    freshDates = [];
+  }
   
   // Step 3: If no dates need fetching, compute total from cache
   if (needFetchDates.length === 0) {
@@ -1041,6 +1053,7 @@ export async function getTotalAdsExpense(
   shopIds: number[],
   startDate: WibDate,
   endDate: WibDate,
+  options: { forceRefresh?: boolean } = {},
 ): Promise<AdsExpenseTotal> {
   // Validate inputs
   if (!Array.isArray(shopIds)) {
@@ -1082,7 +1095,7 @@ export async function getTotalAdsExpense(
       }
       
       // Call getShopExpense
-      const shopTotal = await getShopExpense(shopId, startDate, endDate);
+      const shopTotal = await getShopExpense(shopId, startDate, endDate, options);
       
       // Validate result
       if (!Number.isFinite(shopTotal)) {

--- a/apps/api/src/services/background-sync.service.ts
+++ b/apps/api/src/services/background-sync.service.ts
@@ -990,7 +990,12 @@ class BackgroundSyncService {
         }
 
         const shopIds = shops.map((s) => s.shopId);
-        const result = await getTotalAdsExpense(shopIds, startDate, endDate);
+        // forceRefresh: re-fetch from Shopee instead of trusting the cache.
+        // Shopee revises ad spend retroactively for several days, so a plain
+        // cache-first read leaves past days frozen at their first-fetched value.
+        // The scheduled job exists precisely to keep those numbers accurate, so
+        // it always pulls fresh data and overwrites the cache.
+        const result = await getTotalAdsExpense(shopIds, startDate, endDate, { forceRefresh: true });
         synced = shopIds.length - result.skippedShops.length;
 
         stats.lastSyncTime = new Date();


### PR DESCRIPTION
## Masalah
Biaya iklan di Laporan lebih rendah dari Shopee (Mei 2026: app Rp 9.017.011 vs Shopee ~Rp 9.2jt). Penyebabnya: cache iklan tanggal lampau tidak pernah ditarik ulang, padahal Shopee merevisi angka iklan secara retroaktif beberapa hari setelahnya.

## Perbaikan
- Tambah opsi forceRefresh di getShopExpense/getTotalAdsExpense: tarik ulang semua tanggal dalam rentang (selama masih dalam 6 bulan) lalu timpa cache.
- Background sync iklan (hot 7d/30menit, cold 180d/harian) kini pakai forceRefresh, jadi tiap sync benar-benar update dari Shopee.
- Script backfill-ads-expense.ts dapat flag --force untuk koreksi data lama.

## Verifikasi
- 25 unit test ads-expense lulus.
- Backfill 180 hari --force dijalankan: semua toko OK.
- Mei 2026 terkoreksi: Rp 9.017.011 → Rp 9.180.381 (cocok dengan Shopee).