### PR TITLE
feat(laporan): tata ulang card Ringkasan + layout grid

### DIFF
--- a/apps/web/src/pages/LaporanKeuangan.css
+++ b/apps/web/src/pages/LaporanKeuangan.css
@@ -113,13 +113,47 @@
   border-bottom-color: var(--accent);
 }
 
-/* Stats Grid — uniform cards, auto-fill so every card is the same size and
-   rows wrap cleanly instead of leaving a lone card hanging. */
+/* Stats Grid — fixed 4 columns so 8 cards form a clean 4×2 layout.
+   Collapses to 2 columns on tablets and 1 on phones. */
 .laporan-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 16px;
   margin-bottom: 24px;
+}
+
+@media (max-width: 900px) {
+  .laporan-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .laporan-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Deductions tab: max 3 columns per row (e.g. 6 cards → 3×2). */
+.laporan-stats--cols-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+@media (max-width: 900px) {
+  .laporan-stats--cols-3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .laporan-stats--cols-3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Grand-total row: a single full-width card, not squeezed into a grid column. */
+.laporan-stats--single {
+  grid-template-columns: 1fr;
 }
 
 .laporan-stat-card {

--- a/apps/web/src/pages/LaporanKeuangan.tsx
+++ b/apps/web/src/pages/LaporanKeuangan.tsx
@@ -205,23 +205,11 @@ function TabRingkasan({ startDate, endDate, shopId }: { startDate: string; endDa
         </div>
       )}
 
-      {/* Ringkasan utama */}
+      {/* Ringkasan — satu grid, urutan: revenue → order → pcs → biaya → net profit */}
       <div className="laporan-stats">
         <div className="laporan-stat-card">
           <div className="laporan-stat-label">Total Revenue</div>
           <div className="laporan-stat-value">{formatRupiah(s.totalRevenue)}</div>
-        </div>
-        <div className="laporan-stat-card">
-          <div className="laporan-stat-label">Net Profit</div>
-          <div className={`laporan-stat-value ${s.totalNetProfit >= 0 ? 'positive' : 'negative'}`}>
-            {formatRupiah(s.totalNetProfit)}
-          </div>
-        </div>
-        <div className="laporan-stat-card">
-          <div className="laporan-stat-label">Profit Margin</div>
-          <div className={`laporan-stat-value ${s.profitMarginPercent >= 0 ? 'positive' : 'negative'}`}>
-            {formatPercent(s.profitMarginPercent)}
-          </div>
         </div>
         <div className="laporan-stat-card">
           <div className="laporan-stat-label">Jumlah Order</div>
@@ -231,26 +219,27 @@ function TabRingkasan({ startDate, endDate, shopId }: { startDate: string; endDa
           <div className="laporan-stat-label">Jumlah Pcs</div>
           <div className="laporan-stat-value">{s.totalQty ?? 0}</div>
         </div>
-      </div>
-
-      {/* Rincian biaya */}
-      <div className="laporan-section-label">Rincian Biaya</div>
-      <div className="laporan-breakdown">
-        <div className="laporan-breakdown-card">
-          <div className="laporan-breakdown-label">HPP (Harga Pokok)</div>
-          <div className="laporan-breakdown-value">{formatRupiah(s.totalHpp)}</div>
+        <div className="laporan-stat-card">
+          <div className="laporan-stat-label">HPP (Harga Pokok)</div>
+          <div className="laporan-stat-value">{formatRupiah(s.totalHpp)}</div>
         </div>
-        <div className="laporan-breakdown-card">
-          <div className="laporan-breakdown-label">Biaya Packing</div>
-          <div className="laporan-breakdown-value">{formatRupiah(s.totalPackingCost)}</div>
+        <div className="laporan-stat-card">
+          <div className="laporan-stat-label">Potongan Marketplace</div>
+          <div className="laporan-stat-value">{formatRupiah(s.totalShopeeDeductions)}</div>
         </div>
-        <div className="laporan-breakdown-card">
-          <div className="laporan-breakdown-label">Potongan Marketplace</div>
-          <div className="laporan-breakdown-value">{formatRupiah(s.totalShopeeDeductions)}</div>
+        <div className="laporan-stat-card">
+          <div className="laporan-stat-label">Biaya Iklan</div>
+          <div className="laporan-stat-value">{formatRupiah(s.totalAdCost ?? 0)}</div>
         </div>
-        <div className="laporan-breakdown-card">
-          <div className="laporan-breakdown-label">Biaya Iklan</div>
-          <div className="laporan-breakdown-value">{formatRupiah(s.totalAdCost ?? 0)}</div>
+        <div className="laporan-stat-card">
+          <div className="laporan-stat-label">Biaya Packing</div>
+          <div className="laporan-stat-value">{formatRupiah(s.totalPackingCost)}</div>
+        </div>
+        <div className="laporan-stat-card">
+          <div className="laporan-stat-label">Net Profit</div>
+          <div className={`laporan-stat-value ${s.totalNetProfit >= 0 ? 'positive' : 'negative'}`}>
+            {formatRupiah(s.totalNetProfit)}
+          </div>
         </div>
       </div>
     </div>
@@ -475,7 +464,7 @@ function TabPotongan({ startDate, endDate, shopId }: { startDate: string; endDat
   return (
     <div>
       {loading && <UpdatingChip />}
-      <div className="laporan-stats">
+      <div className="laporan-stats laporan-stats--cols-3">
         <div className="laporan-stat-card">
           <div className="laporan-stat-label">Biaya Administrasi</div>
           <div className="laporan-stat-value">{formatRupiah(d.totalCommission)}</div>
@@ -503,7 +492,7 @@ function TabPotongan({ startDate, endDate, shopId }: { startDate: string; endDat
       </div>
 
       <div className="laporan-section-label">Total</div>
-      <div className="laporan-stats">
+      <div className="laporan-stats laporan-stats--single">
         <div className="laporan-stat-card">
           <div className="laporan-stat-label">Grand Total Potongan</div>
           <div className="laporan-stat-value negative">{formatRupiah(d.grandTotal)}</div>


### PR DESCRIPTION
## Perubahan
- Ringkasan: card jadi satu grid dengan urutan Total Revenue, Jumlah Order, Jumlah Pcs, HPP, Potongan Marketplace, Biaya Iklan, Biaya Packing, Net Profit (maks 4 per baris → 4x2).
- Hapus card Profit Margin.
- Rincian Potongan Marketplace: maks 3 card per baris; Grand Total tetap full-width di bawah.
- Responsif: turun ke 2 lalu 1 kolom di layar sempit.

## Verifikasi
- Build web (Vite) hijau, tanpa diagnostics.