### PR TITLE
fix(pengaturan): rapikan layout tab jadi rata kiri konsisten

### DIFF
--- a/apps/web/src/components/settings/AppearanceSettings.tsx
+++ b/apps/web/src/components/settings/AppearanceSettings.tsx
@@ -78,7 +78,7 @@ export function AppearanceSettings() {
   const { isDark, toggleTheme } = useTheme();
 
   return (
-    <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+    <div style={{ maxWidth: '640px' }}>
       <div style={{ marginBottom: '16px' }}>
         <h2 style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--text1)', marginBottom: '4px' }}>
           Tampilan &amp; Aksesibilitas

--- a/apps/web/src/components/settings/ChangePasswordForm.tsx
+++ b/apps/web/src/components/settings/ChangePasswordForm.tsx
@@ -120,7 +120,7 @@ export function ChangePasswordForm() {
   }
 
   return (
-    <section className="card" style={{ padding: '24px', maxWidth: '460px', margin: '0 auto' }}>
+    <section className="card" style={{ padding: '24px', maxWidth: '460px' }}>
       <h2 style={{ fontSize: '1.05rem', fontWeight: 600, color: 'var(--text1)', marginBottom: '4px' }}>
         Ubah Password
       </h2>

--- a/apps/web/src/components/settings/StaffPermissions.tsx
+++ b/apps/web/src/components/settings/StaffPermissions.tsx
@@ -97,7 +97,7 @@ export function StaffPermissions() {
   }
 
   return (
-    <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+    <div style={{ maxWidth: '640px' }}>
       <div style={{ marginBottom: '16px' }}>
         <h2 style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--text1)', marginBottom: '4px' }}>
           Akses Fitur Staff

--- a/apps/web/src/pages/Pengaturan.tsx
+++ b/apps/web/src/pages/Pengaturan.tsx
@@ -33,7 +33,7 @@ export function Pengaturan() {
 
   return (
     <div className="wms-page animate-fade-in">
-      <div style={{ maxWidth: '1080px', margin: '0 auto' }}>
+      <div style={{ maxWidth: '860px' }}>
         <div className="page-header">
           <div>
             <h1 className="page-title">Pengaturan</h1>


### PR DESCRIPTION
Header, tab bar, dan konten tiap tab kini sejajar dalam satu kolom rata kiri (maks 860px). Sebelumnya konten di-tengah sementara header rata kiri, sehingga ada patahan visual kiri-vs-tengah di tab Akses Staff & Tampilan. Build Vite hijau.