### PR TITLE
feat(shops): soft-disconnect toko — sembunyikan data & skip sync, pulih saat reconnect

### DIFF
--- a/apps/api/drizzle/0035_shop_connection_status.sql
+++ b/apps/api/drizzle/0035_shop_connection_status.sql
@@ -1,0 +1,7 @@
+-- 0035_shop_connection_status.sql
+-- Soft-disconnect support: a shop can be 'disconnected' without deleting its
+-- credentials row. While disconnected, the app hides all of that shop's data
+-- (orders, products, reports) and skips it during sync. Reconnecting (OAuth
+-- re-auth) flips this back to 'connected' and restores everything.
+ALTER TABLE `shopee_credentials`
+  ADD COLUMN `status` VARCHAR(20) NOT NULL DEFAULT 'connected';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780500000000,
       "tag": "0034_order_ship_by_date",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "5",
+      "when": 1780600000000,
+      "tag": "0035_shop_connection_status",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -64,6 +64,11 @@ export const shopeeCredentials = mysqlTable("shopee_credentials", {
   accessToken: text("access_token").notNull(),
   refreshToken: text("refresh_token").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
+  // Connection lifecycle. 'connected' = active (synced + data shown).
+  // 'disconnected' = soft-disconnected: row & shop_name retained, tokens cleared,
+  // all data hidden across the app and sync skipped until the shop is reconnected
+  // (OAuth re-auth flips this back to 'connected').
+  status: varchar("status", { length: 20 }).notNull().default("connected"),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 }, (t) => ({
   uniqShopId: uniqueIndex("uniq_shop_id").on(t.shopId),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -170,7 +170,9 @@ const app = new Elysia()
       // Smart-refresh: proactively refresh any expired/near-expired tokens
       await ensureAllTokensFresh();
 
-      const rows = await db.select().from(shopeeCredentials);
+      // Only list connected shops — disconnected shops are hidden everywhere.
+      const rows = await db.select().from(shopeeCredentials)
+        .where(eq(shopeeCredentials.status, "connected"));
       return {
         success: true,
         data: rows.map(r => ({
@@ -217,7 +219,11 @@ const app = new Elysia()
     }
   })
 
-  // ─── Multi-Seller: Disconnect a shop ────────────────────────
+  // ─── Multi-Seller: Disconnect a shop (soft) ─────────────────
+  // Soft-disconnect: keep the credentials row (so shop name + historical data
+  // survive) but mark it disconnected and clear tokens. All of the shop's data
+  // is then hidden across the app and sync skips it, until it's reconnected via
+  // OAuth re-auth (which flips status back to 'connected').
   .delete("/shopee/credentials/:shopId", async ({ params, set }) => {
     const shopId = parseInt(params.shopId);
     if (!Number.isFinite(shopId)) {
@@ -231,8 +237,16 @@ const app = new Elysia()
         set.status = 404;
         return { success: false, message: `Shop ${shopId} not found` };
       }
-      await db.delete(shopeeCredentials).where(eq(shopeeCredentials.shopId, shopId));
-      console.log(`[shopee-cred] Disconnected shop_id=${shopId}`);
+      await db.update(shopeeCredentials)
+        .set({
+          status: "disconnected",
+          // Clear tokens — we never keep credentials for a disconnected shop.
+          accessToken: "",
+          refreshToken: "",
+          updatedAt: new Date(),
+        })
+        .where(eq(shopeeCredentials.shopId, shopId));
+      console.log(`[shopee-cred] Soft-disconnected shop_id=${shopId} (data hidden, sync skipped)`);
       return { success: true, message: `Shop ${shopId} disconnected` };
     } catch (err: any) {
       set.status = 500;

--- a/apps/api/src/modules/order/order.route.ts
+++ b/apps/api/src/modules/order/order.route.ts
@@ -3,6 +3,7 @@ import { db } from "../../db/client";
 import { shopeeOrders, shopeeOrderItems, shopeeCredentials } from "../../db/schema";
 import { syncShopeeOrdersService } from "../../services/order.service";
 import { shipSingleOrder, shipBatchOrders, fetchAndUpdateTrackingNumber } from "../../services/shipment.service";
+import { getConnectedShopIdSet } from "../../services/active-shops";
 import { desc, eq, inArray } from "drizzle-orm";
 
 // Order SN validation regex (alphanumeric, max 100 chars)
@@ -36,8 +37,12 @@ export const orderRoutes = new Elysia({ prefix: "/orders" })
   // Get order list from local DB with items
   // Optimized: 2 queries instead of N+1, items only for active orders
   .get("/", async () => {
-    // Query 1: Get all orders
-    const records = await db.select().from(shopeeOrders).orderBy(desc(shopeeOrders.createTime));
+    // Only show orders from connected shops (soft-disconnect hides the rest).
+    const connectedShopIds = await getConnectedShopIdSet();
+
+    // Query 1: Get all orders, then drop any from disconnected shops.
+    const allRecords = await db.select().from(shopeeOrders).orderBy(desc(shopeeOrders.createTime));
+    const records = allRecords.filter(o => connectedShopIds.has(o.shopId));
 
     // Query 2: Get items for active/visible orders (READY_TO_SHIP, PROCESSED, SHIPPED, TO_CONFIRM_RECEIVE)
     // COMPLETED orders don't need items in the order list (too many, and already finished)
@@ -86,7 +91,8 @@ export const orderRoutes = new Elysia({ prefix: "/orders" })
     if (shop_id) {
       shopsToSync = [{ shopId: shop_id }];
     } else {
-      shopsToSync = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials);
+      shopsToSync = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials)
+        .where(eq(shopeeCredentials.status, "connected"));
     }
 
     if (shopsToSync.length === 0) {

--- a/apps/api/src/modules/profit/profit.service.ts
+++ b/apps/api/src/modules/profit/profit.service.ts
@@ -133,6 +133,7 @@ import {
 import type { GroupByLevel, OrderCostInput } from "./profit-calculator";
 import { getTotalAdsExpense } from "../../services/ads-expense.service";
 import type { AdsExpenseTotal } from "../../services/ads-expense.service";
+import { getConnectedShopIds } from "../../services/active-shops";
 
 // ─── Exported Query Params Interface ──────────────────────────────────────────
 
@@ -311,6 +312,11 @@ async function fetchCompletedOrdersUncached(
 
   if (shopId !== undefined) {
     conditions.push(eq(shopeeOrders.shopId, shopId));
+  } else {
+    // No specific shop → restrict to connected shops (soft-disconnect, Opsi B).
+    const connectedShopIds = await getConnectedShopIds();
+    if (connectedShopIds.length === 0) return [];
+    conditions.push(inArray(shopeeOrders.shopId, connectedShopIds));
   }
 
   const orderRows = await db
@@ -463,6 +469,11 @@ async function fetchOrdersInRange(
 
   if (shopId !== undefined) {
     conditions.push(eq(shopeeOrders.shopId, shopId));
+  } else {
+    // No specific shop → restrict to connected shops (soft-disconnect, Opsi B).
+    const connectedShopIds = await getConnectedShopIds();
+    if (connectedShopIds.length === 0) return [];
+    conditions.push(inArray(shopeeOrders.shopId, connectedShopIds));
   }
 
   const rows = await db
@@ -639,9 +650,12 @@ async function resolveAdsShopIds(callerShopId?: number): Promise<number[]> {
     return [callerShopId];
   }
   
+  // Only connected shops contribute ad cost when no specific shop is requested
+  // (soft-disconnect hides a disconnected shop's spend from reports — Opsi B).
   const rows = await db
     .select({ shopId: shopeeCredentials.shopId })
-    .from(shopeeCredentials);
+    .from(shopeeCredentials)
+    .where(eq(shopeeCredentials.status, "connected"));
   
   return rows.map((r) => r.shopId);
 }

--- a/apps/api/src/modules/shopee/shopee-auth.route.ts
+++ b/apps/api/src/modules/shopee/shopee-auth.route.ts
@@ -118,6 +118,9 @@ export const shopeeAuthRoutes = new Elysia({ prefix: "/shopee" })
         accessToken: encrypt(data.access_token),
         refreshToken: encrypt(data.refresh_token),
         expiresAt,
+        // (Re)connecting always marks the shop active again — this is what
+        // restores a previously soft-disconnected shop's data and sync.
+        status: "connected",
         updatedAt: new Date(),
       };
 

--- a/apps/api/src/services/active-shops.ts
+++ b/apps/api/src/services/active-shops.ts
@@ -1,0 +1,47 @@
+/**
+ * Active (connected) shop helpers — single source of truth for the
+ * soft-disconnect feature.
+ *
+ * A shop with `status = 'disconnected'` keeps its credentials row (so its name
+ * and historical data survive), but the whole app must behave as if its data
+ * doesn't exist: hidden from orders/products/reports and skipped during sync.
+ * Reconnecting flips status back to 'connected'.
+ *
+ * Every query that lists shops or filters data by shop MUST go through these
+ * helpers so no code path accidentally leaks a disconnected shop's data.
+ */
+import { eq } from "drizzle-orm";
+import { db as defaultDb } from "../db/client";
+import { shopeeCredentials } from "../db/schema";
+
+export const SHOP_STATUS_CONNECTED = "connected";
+export const SHOP_STATUS_DISCONNECTED = "disconnected";
+
+type AnyDb = typeof defaultDb;
+
+/**
+ * Returns the set of shopId values that are currently connected.
+ * Use this to filter any data keyed by shopId (orders, products, fees, ads).
+ */
+export async function getConnectedShopIds(db: AnyDb = defaultDb): Promise<number[]> {
+  const rows = await db
+    .select({ shopId: shopeeCredentials.shopId })
+    .from(shopeeCredentials)
+    .where(eq(shopeeCredentials.status, SHOP_STATUS_CONNECTED));
+  return rows.map((r) => r.shopId);
+}
+
+/** Returns a Set for O(1) membership checks when filtering in memory. */
+export async function getConnectedShopIdSet(db: AnyDb = defaultDb): Promise<Set<number>> {
+  return new Set(await getConnectedShopIds(db));
+}
+
+/** True if the given shop is currently connected. */
+export async function isShopConnected(shopId: number, db: AnyDb = defaultDb): Promise<boolean> {
+  const rows = await db
+    .select({ status: shopeeCredentials.status })
+    .from(shopeeCredentials)
+    .where(eq(shopeeCredentials.shopId, shopId))
+    .limit(1);
+  return rows.length > 0 && rows[0].status === SHOP_STATUS_CONNECTED;
+}

--- a/apps/api/src/services/background-sync.service.ts
+++ b/apps/api/src/services/background-sync.service.ts
@@ -211,7 +211,8 @@ class BackgroundSyncService {
     }
 
     // Get all connected shops
-    const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials);
+    const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials)
+      .where(eq(shopeeCredentials.status, "connected"));
     
     if (shops.length === 0) {
       console.warn('[background-sync] No shops connected, skipping background sync');
@@ -983,7 +984,8 @@ class BackgroundSyncService {
         const startDate = fmt.format(new Date(Date.now() - daysBack * 24 * 60 * 60 * 1000));
         const endDate = fmt.format(new Date(Date.now() - 1 * 24 * 60 * 60 * 1000));
 
-        const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials);
+        const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials)
+          .where(eq(shopeeCredentials.status, "connected"));
         if (shops.length === 0) {
           console.log(`[background-sync] Job "${jobName}" skipped — no shops connected`);
           return;
@@ -1096,7 +1098,8 @@ class BackgroundSyncService {
   async forceSyncOrders(orderStatus?: string, daysBack: number = 15) {
     console.log(`[background-sync] Force sync triggered for status: ${orderStatus || 'ALL'}, days: ${daysBack}`);
     
-    const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials);
+    const shops = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials)
+      .where(eq(shopeeCredentials.status, "connected"));
     let totalSynced = 0;
 
     for (const shop of shops) {

--- a/apps/api/src/services/escrow-sync.service.ts
+++ b/apps/api/src/services/escrow-sync.service.ts
@@ -93,7 +93,8 @@ export class EscrowSyncService {
       // Ambil semua toko yang terdaftar
       const shops = await db
         .select({ shopId: shopeeCredentials.shopId })
-        .from(shopeeCredentials);
+        .from(shopeeCredentials)
+        .where(eq(shopeeCredentials.status, "connected"));
 
       if (shops.length === 0) {
         console.warn("[escrow-sync] No shops found, nothing to sync");

--- a/apps/api/src/services/master.service.ts
+++ b/apps/api/src/services/master.service.ts
@@ -1,6 +1,6 @@
 import { eq, isNull, inArray } from "drizzle-orm";
 import { db } from "../db/client";
-import { masterProducts, products, productGroups, masterProductVariants } from "../db/schema";
+import { masterProducts, products, productGroups, masterProductVariants, shopeeCredentials } from "../db/schema";
 import { 
   updateStockOnShopee, 
   updateStockOnShopeeBatch, 
@@ -466,10 +466,20 @@ export async function importFromListing(shopeeItemId: string) {
 export async function listMasterProducts() {
   const masters = await db.select().from(masterProducts);
 
+  // Only count/show links from connected shops (soft-disconnect hides a
+  // disconnected shop's product links — Opsi B). A master linked solely to
+  // disconnected shops will therefore read as "Unlinked".
+  const connectedRows = await db
+    .select({ shopId: shopeeCredentials.shopId })
+    .from(shopeeCredentials)
+    .where(eq(shopeeCredentials.status, "connected"));
+  const connectedShopIds = new Set(connectedRows.map((r) => r.shopId));
+
   const result = [];
   for (const m of masters) {
-    const linked = await db.select({
+    const linkedAll = await db.select({
       id: products.id,
+      shopId: products.shopId,
       shopeeModelId: products.shopeeModelId,
       shopeeItemId: products.shopeeItemId,
       groupId: products.groupId,
@@ -479,6 +489,9 @@ export async function listMasterProducts() {
       shopeeStock: products.shopeeStock,
       syncStatus: products.syncStatus,
     }).from(products).where(eq(products.masterProductId, m.id));
+
+    // Drop links from disconnected shops.
+    const linked = linkedAll.filter((l) => connectedShopIds.has(l.shopId));
 
     // Get unique product groups for image + group info
     const groupIds = [...new Set(linked.map(l => l.groupId))];

--- a/apps/api/src/services/shopee-auth.ts
+++ b/apps/api/src/services/shopee-auth.ts
@@ -140,7 +140,10 @@ export async function refreshAccessToken(row: TokenRow): Promise<TokenRow> {
  * Called by cron job and smart-refresh endpoints.
  */
 export async function ensureAllTokensFresh(): Promise<{ refreshed: number; failed: number }> {
-  const rows = await db.select().from(shopeeCredentials);
+  // Only refresh connected shops — disconnected ones have their tokens cleared
+  // and must not be touched until reconnected.
+  const rows = await db.select().from(shopeeCredentials)
+    .where(eq(shopeeCredentials.status, "connected"));
   let refreshed = 0;
   let failed = 0;
   const margin = 30 * 60 * 1000; // 30 minutes before expiry

--- a/apps/api/src/services/shopee.service.ts
+++ b/apps/api/src/services/shopee.service.ts
@@ -154,7 +154,8 @@ export async function syncShopeeProducts(targetShopId?: number) {
   if (targetShopId) {
     shopsToSync = [{ shopId: targetShopId }];
   } else {
-    shopsToSync = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials);
+    shopsToSync = await db.select({ shopId: shopeeCredentials.shopId }).from(shopeeCredentials)
+      .where(eq(shopeeCredentials.status, "connected"));
   }
 
   let grandTotalItems = 0;
@@ -330,8 +331,16 @@ async function syncShopeeProductsForShop(shopId: number) {
  * Returns a structured array of items, each with their variants and master linkage.
  */
 export async function getShopeeCatalog() {
-  // 1. Fetch all product groups (items)
-  const groups = await db.select().from(productGroups);
+  // 1. Fetch product groups, but only from connected shops (soft-disconnect
+  //    hides a disconnected shop's products until it's reconnected).
+  const connectedRows = await db
+    .select({ shopId: shopeeCredentials.shopId })
+    .from(shopeeCredentials)
+    .where(eq(shopeeCredentials.status, "connected"));
+  const connectedShopIds = new Set(connectedRows.map((r) => r.shopId));
+
+  const allGroups = await db.select().from(productGroups);
+  const groups = allGroups.filter((g) => connectedShopIds.has(g.shopId));
 
   // 2. Pre-load shop name map from credentials
   const shopRows = await db.select({ shopId: shopeeCredentials.shopId, shopName: shopeeCredentials.shopName }).from(shopeeCredentials);

--- a/apps/web/src/pages/IntegrasiShopee.tsx
+++ b/apps/web/src/pages/IntegrasiShopee.tsx
@@ -66,8 +66,10 @@ function DisconnectModal({ shop, onClose, onConfirm }: any) {
                 Peringatan: Aksi Berisiko Tinggi
               </div>
               <div style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.55 }}>
-                Memutus koneksi akan menghapus token akses dan menghentikan semua sinkronisasi
-                otomatis untuk toko ini. Data produk channel yang sudah tersimpan tidak akan ikut terhapus.
+                Memutus koneksi akan menghentikan sinkronisasi otomatis dan menyembunyikan
+                semua data toko ini (pesanan, produk channel, dan laporan) dari aplikasi.
+                Data tidak dihapus — semuanya akan muncul kembali dan sinkronisasi berjalan lagi
+                begitu Anda menghubungkan ulang toko ini.
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Konsep
Disconnect tidak lagi menghapus credentials. Kini set status='disconnected' + kosongkan token. Selama disconnected, semua data toko disembunyikan di seluruh aplikasi dan sync di-skip. Reconnect via OAuth membalik ke 'connected' dan memulihkan semuanya (Opsi B).

## Perubahan
- Skema: tambah kolom shopee_credentials.status (+ migrasi 0035, sudah diterapkan ke DB)
- Helper terpusat services/active-shops.ts sebagai single source of truth
- Filter connected shop di: daftar pesanan, katalog produk, laporan/profit + iklan, hitungan linked Master Produk, daftar credentials
- Skip shop disconnected di: background sync (3 job), manual order/product sync, escrow sync, token refresh
- Endpoint disconnect = soft (status + kosongkan token); OAuth save set status=connected
- Teks modal disconnect diperbarui (data disembunyikan, bukan dihapus)

## Verifikasi
- Typecheck bersih di semua file yang diubah; build web hijau
- Migrasi terkonfirmasi: kedua toko status=connected