### PR TITLE
chore(branding): rename ke Sentralio + perbarui README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# WMS-Sync
+# Sentralio
+
+> Repository name: `wms-sync` (the product is branded **Sentralio**).
 
 Warehouse Management & Shopee integration system. A monorepo that syncs Shopee orders, manages product master data, prints shipping labels, and reports per-order profit & loss for a multi-store seller operation.
 
 ## Features
 
 - **Shopee integration** — OAuth authorization, order sync, escrow/settlement sync, automatic token refresh
-- **Order management** — order list with shop filtering, batch shipment (dropoff/pickup), batch label printing
+- **Soft connect/disconnect** — disconnecting a shop hides all of its data (orders, channel products, reports) and pauses sync without deleting anything; reconnecting via OAuth restores the data and resumes sync automatically
+- **Order management** — order list with shop filtering, batch shipment (dropoff/pickup), batch label printing, detection of Shopee "tertunda" (held) orders that can't be processed yet
 - **Shipping labels** — generate, cache, and batch-print Shopee shipping labels with custom sender info
 - **Product master** — master products, channel listings, SKU/model mapping, stock propagation across listings in a group
-- **Profit & loss reporting** — per-order, per-shop, and per-product profit analytics including HPP (cost of goods), packing cost, fees, and Shopee Ads expense
+- **Profit & loss reporting** — per-order and per-product profit analytics including HPP (cost of goods), packing cost, marketplace fees, and Shopee Ads expense (auto-refreshed so it tracks Shopee's retroactive adjustments)
 - **Authentication & roles** — session-based login (JWT in HttpOnly cookie), `admin` / `staff` role matrix, brute-force lockout, user management, change password
 - **Picking list** — aggregated pick quantities derived from synced order items
 
@@ -106,6 +109,7 @@ Operational helper scripts (in `apps/api/src/scripts`):
 
 - `reset-password.ts` — set a user's password (`--email`, `--password`)
 - `reactivate-user.ts` — reactivate a deactivated user
+- `backfill-ads-expense.ts` — backfill/refresh Shopee Ads daily expense cache (`[days]`, optional `--force` to overwrite cached values with fresh data from Shopee)
 
 ## Project Structure
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Hubsentra — Warehouse Management System for Shopee marketplace integration" />
-    <title>Hubsentra</title>
+    <meta name="description" content="Sentralio — Warehouse Management System for Shopee marketplace integration" />
+    <title>Sentralio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -61,7 +61,7 @@ export function TopBar({ active }: { active: string }) {
   return (
     <header className="topbar">
       <div className="topbar-left">
-        <span className="bc-root">Hubsentra</span>
+        <span className="bc-root">Sentralio</span>
         <span className="bc-sep">›</span>
         <span className="bc-curr">{meta.label}</span>
       </div>

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -24,7 +24,7 @@ export function Dashboard() {
       <div className="page-header">
         <div>
           <h1 className="page-title">Dashboard</h1>
-          <p className="page-subtitle">Overview of your Hubsentra system</p>
+          <p className="page-subtitle">Overview of your Sentralio system</p>
         </div>
       </div>
 

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -107,13 +107,13 @@ export function LoginPage() {
     >
       <div className="card" style={{ width: '100%', maxWidth: '400px', padding: '40px 32px' }}>
         <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '20px' }}>
-          <img src="/logo.png" alt="Hubsentra" style={{ height: '56px', width: 'auto' }} />
+          <img src="/logo.png" alt="Sentralio" style={{ height: '56px', width: 'auto' }} />
         </div>
         <h1 style={{ fontSize: '1.4rem', fontWeight: 700, marginBottom: '8px', color: 'var(--text1)' }}>
           Masuk
         </h1>
         <p style={{ fontSize: '0.9rem', color: 'var(--text3)', marginBottom: '28px' }}>
-          Masuk ke akun Hubsentra Anda
+          Masuk ke akun Sentralio Anda
         </p>
 
         <form onSubmit={handleSubmit} noValidate>


### PR DESCRIPTION
Rename semua branding user-facing (judul tab, favicon alt, meta, login, header, dashboard) dari Hubsentra ke Sentralio. README diperbarui: judul, fitur soft connect/disconnect, deteksi pesanan tertunda, auto-refresh biaya iklan, dan script backfill-ads-expense --force. Build web hijau.